### PR TITLE
Add INITIALIZE_VALIDATOR_SESSION to infra configs

### DIFF
--- a/backup/deployments.yaml
+++ b/backup/deployments.yaml
@@ -75,6 +75,8 @@ spec:
         env:
           - name: TX_SERVER_URL
             value: {{ .Values.inferno.terminologyServer }}
+          - name: INITIALIZE_VALIDATOR_SESSIONS
+            value: {{ .Values.inferno.initializeValidatorSession  }}
         envFrom:
         - configMapRef:
             name: inferno

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -46,6 +46,8 @@ spec:
         env:
           - name: TX_SERVER_URL
             value: {{ .Values.inferno.terminologyServer }}
+          - name: INITIALIZE_VALIDATOR_SESSIONS
+            value: {{ .Values.inferno.initializeValidatorSession }}
         envFrom:
         - configMapRef:
             name: inferno

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -8,6 +8,7 @@ inferno:
   terminologyServer: "https://tx.dev.hl7.org.au/fhir"
   externalValidatorUrl: null  # This can be overridden during chart deployment
   validatorImageUri: "ghcr.io/beda-software/validator-wrapper:latest"
+  initializeValidatorSession: false
 
 controller:
   enabled: false # Set to true to enable the ingress controller if you have not already installed it, multiple ingress controllers can be installed via https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/


### PR DESCRIPTION
When I encountered an OOM problem on the cluster, I realized that the application couldn't start if the TX server was unavailable. This happens because the inferno-core library initializes the validator at startup.

I think we can prevent the validator from initializing at startup. This could help in cases where the TX server hasn't started yet.

@KyleOps If you have other ideas, I'm happy to discuss them.
Please review the changes.

**References:**

1. https://github.com/hl7au/au-fhir-core-inferno/issues/243
2. https://github.com/inferno-framework/inferno-core/blob/4331857a54c4bf8ef91e4f9223d4633317f0c49a/lib/inferno/config/boot/validator.rb#L5
3. https://github.com/inferno-framework/inferno-core/blob/4331857a54c4bf8ef91e4f9223d4633317f0c49a/lib/inferno/jobs/invoke_validator_session.rb#L4