### PR TITLE
Add Aus CVD Risk-i test kit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'pg'
 
 gem 'au_core_test_kit', '~> 1.0.0'
 gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: 'ac786b5aa42a347f7da9eb514f33f2f7705c2a1a'
+gem 'auscvdrisk_inferno'
 gem 'validation_test_kit', git: 'https://github.com/beda-software/validation-test-kit'
 
 gem 'sidekiq-cron'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       inferno_core (>= 0.6.1)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)
-    auscvdrisk_inferno (0.1.0)
+    auscvdrisk_inferno (0.2.0)
       inferno_core (~> 0.6.2)
     base62-rb (0.3.1)
     base64 (0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       inferno_core (>= 0.6.1)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)
+    auscvdrisk_inferno (0.1.0)
+      inferno_core (~> 0.6.2)
     base62-rb (0.3.1)
     base64 (0.2.0)
     bcp47 (0.3.3)
@@ -421,6 +423,7 @@ PLATFORMS
 DEPENDENCIES
   au_core_test_kit (~> 1.0.0)
   au_ps_inferno!
+  auscvdrisk_inferno
   database_cleaner-sequel (~> 1.8)
   factory_bot (~> 6.1)
   inferno_core (= 0.6.2)

--- a/lib/inferno_platform_template.rb
+++ b/lib/inferno_platform_template.rb
@@ -1,2 +1,3 @@
 require 'au_core_test_kit'
 require 'au_ps_inferno'
+require 'auscvdrisk'


### PR DESCRIPTION
This change adds a new test kit for the [Australian CVD Risk Calculator implementation guide](https://go.csiro.au/FwLink/auscvdrisk-ig-development).

I have published this to [RubyGems](https://rubygems.org/gems/auscvdrisk_inferno), added it to the dependencies and included it.

I have attempted to verify that this works locally - I can see it on the suites page and I can run the tests.

<img width="855" height="811" alt="Screenshot 2025-07-15 at 1 49 43 PM" src="https://github.com/user-attachments/assets/790419de-e65e-4580-8353-54f813e499e5" />

Some things I might need help with:

- Adding it to the "Test kits" page, along with metadata such as description and maturity
- I added the IG package to the `igs` directory, not sure if this was the right thing to do