### PR TITLE
fix(validator): relax liveness probe + raise CPU limit for heavy validation runs

### DIFF
--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -42,7 +42,10 @@ spec:
             cpu: "1000m"
           limits:
             memory: "12Gi"
-            cpu: "2000m"
+            cpu: "3000m"   # raised from 2000m for burst headroom (validations are CPU-bound and starved
+                           # the health endpoint). Request stays 1000m: scheduling is memory-driven (10Gi)
+                           # onto 2-4 vCPU r-family nodes, so this is a burst ceiling under a 4-vCPU node's
+                           # ~3920m allocatable, leaving room for node DaemonSets/kubelet.
         startupProbe:
           httpGet:
             path: /
@@ -66,8 +69,10 @@ spec:
             port: 3500
           initialDelaySeconds: 60
           periodSeconds: 30
-          timeoutSeconds: 10      # Increased from 5s - preset loading can block briefly
-          failureThreshold: 5     # Increased from 3 - allows 150s (5*30) before restart
+          timeoutSeconds: 30      # baseEngine generateSnapshot() saturates Ktor threads; a single
+                                  # validation can run ~160s and block the health endpoint
+          failureThreshold: 10    # allows 300s (10*30) before restart - covers a full validation/preset
+                                  # load so a busy (not wedged) validator is not killed mid-session
   volumeClaimTemplates:
   - metadata:
       name: fhir-package-cache


### PR DESCRIPTION
Prod validator-api was being restarted mid-validation: a single validation can run ~160s and saturate Ktor threads, so the liveness probe (10s timeout, 150s grace) timed out and the kubelet killed the pod → in-flight validations failed with `Faraday::ConnectionFailed` from the inferno worker.

- **livenessProbe**: timeout 10→30s, failureThreshold 5→10 (300s grace). Matches the relaxed values already on `development`; brings master/prod in line. Readiness unchanged (still removes a truly-wedged pod).
- **CPU limit** 2000m→3000m for burst headroom; request stays 1000m (scheduling is memory-driven onto 2-4 vCPU r-family nodes, so this is a burst ceiling under a 4-vCPU node's ~3920m allocatable). Diagnosed on the sparkey cluster: liveness-probe kills under load.