### PR TITLE
chore(redis): upgrade inferno-redis to 8.2-alpine (dev)

### DIFF
--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -17,7 +17,7 @@ spec:
         kubernetes.io/arch: amd64
       containers:
       - name: redis
-        image: redis:7.0.5-bullseye
+        image: redis:8.2-alpine
         imagePullPolicy: Always
         ports:
           - containerPort: 6379


### PR DESCRIPTION
Bump inferno-redis from EOL `redis:7.0.5-bullseye` to `redis:8.2-alpine` (current stable, Alpine base — smaller + fewer CVEs). PVC data carries over (Redis reads older RDB/AOF); Sidekiq supports Redis 6.2+. Dev first; prod (master) follows after verification, with an added on-demand nodeSelector.