### PR TITLE
chore(redis): 8.2-alpine + pin inferno-redis to on-demand (prod)

### DIFF
--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -15,9 +15,10 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # avoid spot reclamation taking the single-replica job queue down mid-run
       containers:
       - name: redis
-        image: redis:7.0.5-bullseye
+        image: redis:8.2-alpine
         imagePullPolicy: Always
         ports:
           - containerPort: 6379


### PR DESCRIPTION
Follows the dev bump (PR #58, verified ~3s downtime + auto-reconnect).

- **Image** `redis:7.0.5-bullseye` (EOL) → `redis:8.2-alpine`. PVC data carries over; Sidekiq supports Redis 6.2+.
- **Pin redis to on-demand** (prod only): a **spot interruption** took the single-replica/no-PDB redis down in both envs and disrupted active test runs. Spot reclamation is involuntary (PDB/do-not-disrupt can't prevent it) — on-demand does. Dev stays on spot.