### PR TITLE
fix(redis): Recreate strategy for single-replica RWO PVC

### DIFF
--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1 # need clustering for multiple replicas
+  strategy:
+    type: Recreate   # single-replica + RWO EBS PVC: terminate old before new to avoid Multi-Attach deadlock
   selector:
     matchLabels:
       app: inferno-redis


### PR DESCRIPTION
The 8.2-alpine + on-demand change deadlocked: RollingUpdate created the new redis pod before terminating the old, but the RWO EBS volume was still held by the old pod (`Multi-Attach error`). `strategy: Recreate` terminates old-before-new so the volume releases. (Old pod kept serving throughout — no outage, just a stuck roll.)