### PR TITLE
fix(redis): Recreate strategy (dev, match master)

### DIFF
--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1 # need clustering for multiple replicas
+  strategy:
+    type: Recreate   # single-replica + RWO EBS PVC: terminate old before new to avoid Multi-Attach deadlock
   selector:
     matchLabels:
       app: inferno-redis


### PR DESCRIPTION
Mirror the Recreate strategy applied to master so dev redis doesn't deadlock on a future spec change. Zero impact now (strategy change doesn't restart pods).