### PR TITLE
feat(prod): pin inferno worker/app/validator to on-demand

### DIFF
--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       containers:
       - name: inferno-worker
         image: {{ .Values.inferno.imageUrl }}

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       volumes:
         - name: examplenginx-config
           configMap:

--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         fsGroup: 1000  # Ensures volumes are writable by ktor user (UID 1000)
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       containers:
       - name: validator-api
         image: {{ .Values.inferno.validatorImageUri }}


### PR DESCRIPTION
A sustained spot-interruption storm repeatedly churned prod inferno-worker/app/validator (connection-failure bursts on every reschedule). redis was already pinned; pin the rest of the prod test-run path so runs aren't disrupted by spot reclamation. Prod (master) only — dev stays on spot. One-time reschedule to on-demand when it rolls out, then stable. nginx-app left on spot.