### PR TITLE
Separate dev/prod test-kit dependencies via Gemfile.dev

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -30,9 +30,13 @@ jobs:
           if [ "$GITHUB_REF" = "refs/heads/development" ]; then
             echo "environment=dev" >> $GITHUB_OUTPUT
             echo "rake_task=web:generate_dev" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile.dev" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile.dev" >> $GITHUB_ENV
           else
             echo "environment=prod" >> $GITHUB_OUTPUT
             echo "rake_task=web:generate_prod" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> $GITHUB_ENV
           fi
 
       - name: Set up Ruby
@@ -68,6 +72,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            BUNDLE_GEMFILE=${{ steps.config.outputs.bundle_gemfile }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ steps.config.outputs.environment }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,18 @@ RUN mkdir -p $INSTALL_PATH
 
 WORKDIR $INSTALL_PATH
 
-ADD *.gemspec $INSTALL_PATH
+# Select the dependency set: the default Gemfile (prod / released test kits) or
+# Gemfile.dev (bleeding-edge, unreleased test-kit commits) for the dev environment.
+# Each Gemfile has its own committed lockfile (Gemfile.lock / Gemfile.dev.lock).
+ARG BUNDLE_GEMFILE=Gemfile
+ENV BUNDLE_GEMFILE=$INSTALL_PATH$BUNDLE_GEMFILE
+
+# Gemfile* also matches Gemfile.common, Gemfile.dev and the *.lock files.
 ADD Gemfile* $INSTALL_PATH
 RUN gem install bundler
-# The below RUN line is commented out for development purposes, because any change to the 
-# required gems will break the dockerfile build process.
-# If you want to run in Deploy mode, just run `bundle install` locally to update 
-# Gemfile.lock, and uncomment the following line.
-# RUN bundle config set --local deployment 'true'
-RUN bundle install
+# Frozen mode: build strictly from the committed lockfile so the image is reproducible
+# and the build fails fast if the lockfile is out of sync with the Gemfile.
+RUN bundle config set --local frozen 'true' && bundle install
 
 ADD . $INSTALL_PATH
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,38 +1,25 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+# PRODUCTION / released dependency set. This is the DEFAULT Gemfile (the one bundler
+# uses unless BUNDLE_GEMFILE says otherwise) and the set that ships to prod
+# (inferno.hl7.org.au). It pins the test kits to RELEASED gem versions, or to a stable
+# commit where no release exists yet.
+#
+# For the dev environment and local work against bleeding-edge, unreleased test-kit
+# commits, use Gemfile.dev (which has its own Gemfile.dev.lock):
+#
+#   BUNDLE_GEMFILE=Gemfile.dev bundle install
+#
+# Keeping the unreleased test-kit SHAs in Gemfile.dev means this file and Gemfile.lock
+# stay identical on the development and master branches, so development -> master
+# merges never conflict on — or silently leak unreleased versions into — prod.
 
-ruby '3.3.6'
+eval_gemfile 'Gemfile.common'
 
-gem 'inferno_core', '~> 1.0.6'
-gem 'pg'
+# Released AU Core test kit (published on RubyGems by hl7au).
+# NOTE: the newest published version is 1.4.0; code on the kit's master is ahead
+# (1.4.2, unreleased). Once 1.4.2 is tagged + released, bump this to '~> 1.4'.
+gem 'au_core_test_kit', '~> 1.4.0'
 
-# This loads the test kit suites
-# These are published on Ruby Gems, but you can
-# also point to git repos, or with some extra
-# Docker configuration relative directories
-
-gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno', ref: '1446b9bf9016cbcf27871175ea69dd32c698c940'
-# gem 'au_core_test_kit', '~> 1.4.0'
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '98678b39d17be1fd421aabce0b52b2f565a6b540'
-gem 'validation_test_kit', git: 'https://github.com/beda-software/validation-test-kit'
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'b7d35902727343e898cd8d03dff600823b15384c'
-
-
-gem 'sinatra'
-gem 'sidekiq-cron'
-
-# OpenTelemetry — worker emits spans to Alloy → Tempo
-gem 'opentelemetry-sdk'
-gem 'opentelemetry-exporter-otlp'
-gem 'opentelemetry-instrumentation-faraday'
-gem 'opentelemetry-instrumentation-net_http'
-gem 'opentelemetry-instrumentation-sidekiq'
-
-group :development, :test do
-  gem 'jekyll'
-  gem 'database_cleaner-sequel', '~> 1.8'
-  gem 'factory_bot', '~> 6.1'
-  gem 'rspec', '~> 3.10'
-  gem 'webmock', '~> 3.11'
-end
+# AU PS test kit — no RubyGems release exists yet, so pin a stable commit.
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf'

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Shared dependency set, eval'd by BOTH Gemfile (prod / released) and Gemfile.dev
+# (bleeding-edge test-kit commits). The test-kit gems that intentionally DIFFER
+# between environments — au_core_test_kit and au_ps_inferno — are declared in the
+# including Gemfile, NOT here. Everything in this file is identical across envs and
+# flows to prod normally.
+
+source "https://rubygems.org"
+
+ruby '3.3.6'
+
+gem 'inferno_core', '~> 1.0.6'
+gem 'pg'
+
+# Test-kit support gems. Currently the same commit in every environment, so they live
+# here. Pinned to explicit refs for reproducibility (validation_test_kit previously
+# floated to the beda-software default branch, including in prod).
+gem 'validation_test_kit', git: 'https://github.com/beda-software/validation-test-kit', ref: '3438159ae5860216d37c559725fbfdc316ad745c'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'b7d35902727343e898cd8d03dff600823b15384c'
+
+gem 'sinatra'
+gem 'sidekiq-cron'
+
+# OpenTelemetry — worker emits spans to Alloy → Tempo
+gem 'opentelemetry-sdk'
+gem 'opentelemetry-exporter-otlp'
+gem 'opentelemetry-instrumentation-faraday'
+gem 'opentelemetry-instrumentation-net_http'
+gem 'opentelemetry-instrumentation-sidekiq'
+
+group :development, :test do
+  gem 'jekyll'
+  gem 'database_cleaner-sequel', '~> 1.8'
+  gem 'factory_bot', '~> 6.1'
+  gem 'rspec', '~> 3.10'
+  gem 'webmock', '~> 3.11'
+end

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# DEVELOPMENT dependency set: tracks bleeding-edge, unreleased test-kit commits for the
+# dev environment (development.inferno.sparked-fhir.com) and local development. It has
+# its OWN lockfile, Gemfile.dev.lock. Select it with:
+#
+#   BUNDLE_GEMFILE=Gemfile.dev bundle install
+#
+# Do NOT move these unreleased SHAs into the base Gemfile — keeping them quarantined
+# here is what stops a development -> master merge from dragging unreleased test-kit
+# versions into prod. Bump the refs below when dev should track newer commits.
+
+eval_gemfile 'Gemfile.common'
+
+# Bleeding-edge AU Core test kit — unreleased commit ahead of the RubyGems release.
+gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno', ref: '1446b9bf9016cbcf27871175ea69dd32c698c940'
+
+# Bleeding-edge AU PS test kit.
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '98678b39d17be1fd421aabce0b52b2f565a6b540'

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -7,9 +7,19 @@ GIT
       inferno_core (>= 0.4.2)
 
 GIT
+  remote: https://github.com/hl7au/au-fhir-core-inferno
+  revision: 1446b9bf9016cbcf27871175ea69dd32c698c940
+  ref: 1446b9bf9016cbcf27871175ea69dd32c698c940
+  specs:
+    au_core_test_kit (1.4.2)
+      inferno_core (>= 1.0.6)
+      smart_app_launch_test_kit (>= 0.4.0)
+      tls_test_kit (~> 0.2.0)
+
+GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf
-  ref: 7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf
+  revision: 98678b39d17be1fd421aabce0b52b2f565a6b540
+  ref: 98678b39d17be1fd421aabce0b52b2f565a6b540
   specs:
     au_ps_inferno (0.0.1)
       inferno_core (~> 1.0.6)
@@ -38,10 +48,6 @@ GEM
     aes_key_wrap (1.1.0)
     anonymous_loader (0.1.2)
       version_gem (~> 1.1, >= 1.1.13)
-    au_core_test_kit (1.4.0)
-      inferno_core (>= 1.0.6)
-      smart_app_launch_test_kit (>= 0.4.0)
-      tls_test_kit (~> 0.2.0)
     auth-sanitizer (0.2.2)
       version_gem (~> 1.1, >= 1.1.10)
     base62-rb (0.3.1)
@@ -528,7 +534,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  au_core_test_kit (~> 1.4.0)
+  au_core_test_kit!
   au_ps_inferno!
   database_cleaner-sequel (~> 1.8)
   factory_bot (~> 6.1)

--- a/compose.generate.yml
+++ b/compose.generate.yml
@@ -2,6 +2,8 @@ services:
   inferno:
     build:
       context: ./
+      args:
+        BUNDLE_GEMFILE: Gemfile.dev
     mem_limit: 1500m
     restart: unless-stopped
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,9 @@ services:
   inferno_web:
     build:
       context: ./
+      args:
+        # Local development tracks the bleeding-edge test-kit commits.
+        BUNDLE_GEMFILE: Gemfile.dev
     mem_limit: 1500m
     restart: unless-stopped
     volumes:
@@ -23,6 +26,8 @@ services:
   inferno_worker:
     build:
       context: ./
+      args:
+        BUNDLE_GEMFILE: Gemfile.dev
     command: /opt/inferno/worker.sh
     mem_limit: 2000m
     restart: unless-stopped


### PR DESCRIPTION
Closes #63. Part of #68 (Phase 1.1).

## Why
The dev/prod test-kit version split was maintained by hand-commenting lines in a single `Gemfile`, so every `development -> master` merge conflicted on `Gemfile` and `Gemfile.lock` and risked silently leaking unreleased test-kit commits into prod.

## What
- `Gemfile.common` — shared gems; `validation_test_kit` is now pinned (it previously floated to a default branch, including in prod).
- `Gemfile` (default/prod) — `au_core_test_kit ~> 1.4.0` (released), `au_ps_inferno` at `7dce73a` (current prod ref). `eval_gemfile 'Gemfile.common'`.
- `Gemfile.dev` (+ committed `Gemfile.dev.lock`) — bleeding-edge `au_core_test_kit @1446b9b` (1.4.2), `au_ps_inferno @98678b3`. Selected via `BUNDLE_GEMFILE`.
- `Dockerfile` — `BUNDLE_GEMFILE` build arg + frozen install for reproducible images.
- CI — dev images build from `Gemfile.dev`, prod from the default `Gemfile`.
- `compose.yml` / `compose.generate.yml` — local dev tracks `Gemfile.dev` (unchanged behaviour).

Result: the prod `Gemfile` and `Gemfile.lock` are byte-identical on `development` and `master`, so merges no longer conflict on dependencies or drag unreleased versions into prod.

## Verification
Lockfiles generated with Ruby 3.3.6 / bundler 2.6.3 against RubyGems + the git sources, in a clean `GEM_HOME` so local gems could not leak a phantom version. Prod lock resolves `au_core_test_kit 1.4.0` (the published release — matching current master); dev lock resolves `1.4.2` from the git ref. Both pass `BUNDLE_FROZEN=true` consistency checks and include the `x86_64-linux` platform used by CI.

> Note: `infra/helm` and the prod-promotion path are unchanged here; merging to `development` is required to exercise the dev image build end to end.