### PR TITLE
ci: promote prod image via reviewed PR on master push

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -27,7 +27,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -117,23 +116,27 @@ jobs:
           sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ steps.config.outputs.environment }}|" infra/helm/inferno/values-prod.yaml
           sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-${{ steps.config.outputs.environment }}|" infra/helm/inferno/values-prod.yaml
 
-      - name: Open prod promotion PR
+      # Push the bump to a dedicated branch and surface a one-click "open PR" link in
+      # the run summary. A human opens + merges that PR = the prod release. This uses
+      # only contents:write (the same permission the dev commit-back already uses) and
+      # needs no repo-admin "Actions can create PRs" setting.
+      - name: Push prod promotion branch
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: master
-          branch: promote/prod-${{ github.sha }}
-          add-paths: infra/helm/inferno/values-prod.yaml
-          commit-message: "chore: promote prod image to ${{ github.sha }}"
-          title: "Promote prod image to ${{ github.sha }}"
-          body: |
-            Automated production image promotion. Merging this PR is the prod release —
-            ArgoCD (sparked-argo, `targetRevision: master`) syncs the new tags to
-            `prod-inferno` → https://inferno.hl7.org.au.
-
-            Built from `${{ github.sha }}` on `master`:
-            - app:   `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-prod`
-            - nginx: `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-prod`
-          labels: prod-promotion
-          delete-branch: true
+        run: |
+          BRANCH="promote/prod-${{ github.sha }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add infra/helm/inferno/values-prod.yaml
+          git commit -m "chore: promote prod image to ${{ github.sha }}"
+          git push --force-with-lease origin "$BRANCH"
+          {
+            echo "## 🚀 Prod promotion ready"
+            echo ""
+            echo "Open a PR to release these images to prod (merging it = the release):"
+            echo ""
+            echo "**https://github.com/${{ github.repository }}/compare/master...$BRANCH?expand=1**"
+            echo ""
+            echo "- app:   \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-prod\`"
+            echo "- nginx: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-prod\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -14,12 +14,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Serialise runs per branch so the dev image commit-back cannot race a concurrent
+# push (avoids non-fast-forward push failures). Do not cancel in-progress builds —
+# they may be mid image push.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-push-images:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,3 +107,33 @@ jobs:
           git add infra/helm/inferno/values-dev.yaml
           git commit -m "chore: update dev image to ${{ github.sha }} [skip ci]"
           git push origin development
+
+      # Prod is promoted via a reviewed PR (not a direct commit): merging the PR is the
+      # release. ArgoCD (sparked-argo, targetRevision: master) syncs the new tags to
+      # prod-inferno on merge.
+      - name: Update image tags in values-prod.yaml
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: |
+          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ steps.config.outputs.environment }}|" infra/helm/inferno/values-prod.yaml
+          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-${{ steps.config.outputs.environment }}|" infra/helm/inferno/values-prod.yaml
+
+      - name: Open prod promotion PR
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: master
+          branch: promote/prod-${{ github.sha }}
+          add-paths: infra/helm/inferno/values-prod.yaml
+          commit-message: "chore: promote prod image to ${{ github.sha }}"
+          title: "Promote prod image to ${{ github.sha }}"
+          body: |
+            Automated production image promotion. Merging this PR is the prod release —
+            ArgoCD (sparked-argo, `targetRevision: master`) syncs the new tags to
+            `prod-inferno` → https://inferno.hl7.org.au.
+
+            Built from `${{ github.sha }}` on `master`:
+            - app:   `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-prod`
+            - nginx: `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-prod`
+          labels: prod-promotion
+          delete-branch: true


### PR DESCRIPTION
Closes #64. Part of #68 (Phase 1.2).

## Why
Prod promotion was a manual edit of a 40-char SHA in `values-prod.yaml` — error-prone, and "merge to master" alone didn't deploy prod (it could silently lag master HEAD).

## What
On push to `master`, after the `<sha>-prod` images are built:
- `sed` updates `values-prod.yaml` `imageUrl`/`platformImageUri` to the new tags.
- A **`promote/prod-<sha>` branch** is pushed with that bump, and a one-click **compare/open-PR link** is written to the workflow run summary.
- A human opens + merges that PR. **Merging it is the production release** — ArgoCD (sparked-argo, `targetRevision: master`) syncs the tags to `prod-inferno`.

This deliberately uses only `contents: write` (the same permission the existing dev commit-back already uses) — **no repo-admin settings required**. (Earlier revision used `create-pull-request`, which needs the admin-only "Allow GitHub Actions to create and approve pull requests" setting we can't enable; reworked to avoid it.)

Also:
- Added a `concurrency: build-<ref>` group (no cancel) so the dev image commit-back can't race a concurrent push.
- Dev path unchanged (direct commit-back, fast iteration).

## Notes
- Only fires on a `master` push, i.e. a `development → master` merge.
- Removing the dead `prod` branch trigger + other cleanup is tracked in #65.
- Validated: workflow YAML parses.