### PR TITLE
chore: governance scaffolding (PR template, CODEOWNERS, board auto-add)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners — GitHub auto-requests these reviewers when matching files change.
+# NOTE: starting default only — replace with the real review owners/team.
+# Available maintainers: @ir4y @projkov @xmhorsehead @KyleOps @heathfrankel @Sudo-JHare
+#
+# Enforcement (requiring owner review before merge) needs branch protection on
+# master, which is a repo-admin action — see the CI/CD overhaul plan (Track B).
+
+# Default owner for everything in the repo.
+*                       @KyleOps
+
+# Deployment + CI/CD surface.
+/.github/               @KyleOps
+/infra/                 @KyleOps
+/Dockerfile             @KyleOps
+/nginx.Dockerfile       @KyleOps
+/Gemfile                @KyleOps
+/Gemfile.lock           @KyleOps
+/Gemfile.common         @KyleOps

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+<!-- What does this PR change, and why? -->
+
+## Related board item
+<!-- Link the tracking issue. Use a closing keyword if this PR completes it so the
+     board status advances automatically (e.g. "Closes #123", or "Part of #123"). -->
+Closes #
+
+## Type
+- [ ] Feature / enhancement
+- [ ] Fix
+- [ ] CI/CD / infra
+- [ ] Docs
+
+## Checklist
+- [ ] Targets the right base branch (`development` for app/content; prod is reached via the automated promotion PR on `master`)
+- [ ] If test-kit versions changed, only `Gemfile.dev` / `Gemfile.dev.lock` were touched — the prod `Gemfile` / `Gemfile.lock` are unchanged (unless intentionally promoting a release to prod)
+- [ ] `quality-control` / tests pass
+- [ ] Any deployment-config change was checked against dev

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,43 @@
+name: Add issues and PRs to project board
+
+# Adds new issues/PRs in this repo to the org board
+# (https://github.com/orgs/hl7au/projects/2), excluding automated/dependency PRs.
+#
+# Requires an org secret ADD_TO_PROJECT_PAT (a token with org Projects: read & write
+# and repo Issues/PRs: read) — see the CI/CD overhaul plan (Track B). Until that secret
+# exists the job is a graceful no-op, so this workflow is safe to merge now.
+#
+# NOTE: issue/PR-triggered workflows run from the DEFAULT branch, so this only takes
+# effect once it has reached `master`.
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for project token
+        id: check
+        env:
+          TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ADD_TO_PROJECT_PAT not set — board auto-add disabled until the org secret is provisioned."
+          fi
+
+      - name: Add to project
+        if: steps.check.outputs.enabled == 'true'
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/hl7au/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          # Keep automated/dependency PRs off the board.
+          labeled: automated-pr, dependencies
+          label-operator: NOT

--- a/docs/cicd-overhaul-plan.md
+++ b/docs/cicd-overhaul-plan.md
@@ -52,6 +52,14 @@ was toggled by commenting lines per branch — the source of the merge pain.
   misconfiguration. Do not add a prod override.
 - No branch protection exists on `master` or `development` in any repo.
 
+### Permissions reality
+
+The team currently has the **`maintain`** role on these repos, not **`admin`**. So we
+can: push branches, merge PRs, create releases, and add/modify any files or workflows.
+We **cannot**: set branch protection/rulesets, change repo Actions settings, or create
+repo/org secrets. Those few admin/org actions are batched into **Track B** below for the
+repo/org owner (Brett). Everything else proceeds through normal PR / merge / Actions.
+
 ---
 
 ## Decisions
@@ -138,10 +146,29 @@ Per-PR ephemeral deploys so any branch can get a live URL.
 
 ---
 
+## Track B — needs the repo/org owner (Brett)
+
+Batched admin/org actions we can't perform with `maintain`. Each has a no-admin interim
+so work continues meanwhile.
+
+| Item | Why it needs admin | Interim |
+| --- | --- | --- |
+| **Branch protection / ruleset on `master`** (require PR + 1 review + passing `quality-control`) | Repo-admin only | Prod gate is "a human merges the promotion PR" — works, just not enforced. CODEOWNERS already auto-requests reviewers. |
+| **Org secret `ADD_TO_PROJECT_PAT`** + approve a fine-grained org PAT (Projects R/W + repo Issues/PRs read) | Org/repo-admin only | `add-to-project` workflow is merged but a graceful no-op until the secret exists; board populated manually via `gh` (has `project` scope). |
+
+Explicitly **not** needed: the "Allow GitHub Actions to create and approve pull requests"
+setting — the prod-promotion workflow was reworked to push a branch + surface a one-click
+PR link, so it needs only `contents: write`.
+
 ## Open items needing a decision
 
-- **Auto-add token**: create a fine-grained org token (Org projects R/W + repo issues/PRs
-  read) stored as an org secret. (Approved in principle.)
+- **Dev validator image** `markiantorno/validator-wrapper:latest` (prod pins `1.0.68`): is
+  dev intentionally tracking latest (like the tx server), or should it be pinned?
+- **`prod` branch trigger** in `build-and-release-package.yaml`: the `prod` branch is stale
+  (last used 2025-10-30). Remove the trigger, or is it still part of a flow?
+- **Terraform consolidation**: merge the two near-duplicate Terraform workflows and add a
+  prod-`apply` gate via `workflow_dispatch` (no-admin) rather than GitHub Environments.
 - **Org-level `RUBYGEMSKEY`**: unverified (gh 403). Each kit repo already has its own
   `RUBYGEMSKEY`, so per-repo publishing is unblocked regardless. Trusted publishing (OIDC)
   is the cleaner long-term option.
+- **CODEOWNERS owners**: seeded with `@KyleOps`; set the real owners/team.


### PR DESCRIPTION
Part of #68. Addresses the no-admin parts of #66 and preps #67.

## What
- **`.github/PULL_REQUEST_TEMPLATE.md`** — requires a board-item link (`Closes #…`) so the board's merged→Done flow works, plus a branch/Gemfile checklist.
- **`.github/CODEOWNERS`** — auto-requests reviewers on matching files. Seeded with `@KyleOps` as a placeholder — **please set the real owners/team**. (Enforced *required* review needs branch protection = repo-admin → Track B.)
- **`.github/workflows/add-to-project.yml`** — adds new issues/PRs to [project #2](https://github.com/orgs/hl7au/projects/2), excluding `automated-pr`/`dependencies`-labelled PRs. **Gracefully no-ops until the `ADD_TO_PROJECT_PAT` org secret exists**, so it's safe to merge now; it activates once on `master` + secret provisioned (issue/PR-triggered workflows run from the default branch).
- **`docs/cicd-overhaul-plan.md`** — records the `maintain`-not-`admin` reality and the batched Track B (owner) items.

## Not in scope (tracked elsewhere)
- Branch protection on `master` → Track B (Brett).
- The `ADD_TO_PROJECT_PAT` secret → Track B (Brett).

Validated: both new YAML files parse.