### PR TITLE
ci: pin nginx base image for reproducible builds

### DIFF
--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,3 +1,4 @@
-FROM nginx:latest
+# Pinned (was nginx:latest) for reproducible builds — bump deliberately.
+FROM nginx:1.27
 COPY ./_site /var/www/inferno/public/
 COPY ./nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Part of #65 (reproducibility).

Pins `nginx.Dockerfile` from `nginx:latest` to `nginx:1.27` so the nginx image is reproducible. Static file serving + the existing `nginx.conf` are unaffected across nginx 1.27.x.

Remaining #65 items (dev validator `:latest`, the stale `prod` branch trigger, Terraform consolidation/gate) involve intent/risk decisions and are listed as open questions in `docs/cicd-overhaul-plan.md` — kept out of this PR.