### PR TITLE
deps: adopt released au_core_test_kit 1.4.2 for prod

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     aes_key_wrap (1.1.0)
     anonymous_loader (0.1.2)
       version_gem (~> 1.1, >= 1.1.13)
-    au_core_test_kit (1.4.0)
+    au_core_test_kit (1.4.2)
       inferno_core (>= 1.0.6)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)


### PR DESCRIPTION
Closes the downstream half of hl7au/au-fhir-core-inferno#287. Part of #68 (Phase 1.5).

`au_core_test_kit 1.4.2` is now published to RubyGems. The prod `Gemfile` already constrains `~> 1.4.0` (which allows 1.4.2), so this just refreshes `Gemfile.lock` to resolve 1.4.2 — a 1-line change. Prod now runs the same AU Core code as dev (dev pins the 1.4.2 git SHA in `Gemfile.dev`), but via a proper released gem instead of a SHA.

Reaches prod on the next `development → master` merge. Frozen check passes; `Gemfile.dev.lock` unchanged.