### PR TITLE
deps: adopt au_ps_inferno noEcosystem perf fix (dev + prod)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ eval_gemfile 'Gemfile.common'
 # (1.4.2, unreleased). Once 1.4.2 is tagged + released, bump this to '~> 1.4'.
 gem 'au_core_test_kit', '~> 1.4.0'
 
-# AU PS test kit — no RubyGems release exists yet, so pin a stable commit.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf'
+# AU PS test kit — no RubyGems release exists yet, so pin a stable commit on master
+# (currently master HEAD, which includes the noEcosystem validator perf fix).
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '3cda64eeb2fd1c1677d937cd724aa52b98b62617'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -15,5 +15,6 @@ eval_gemfile 'Gemfile.common'
 # Bleeding-edge AU Core test kit — unreleased commit ahead of the RubyGems release.
 gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno', ref: '1446b9bf9016cbcf27871175ea69dd32c698c940'
 
-# Bleeding-edge AU PS test kit.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '98678b39d17be1fd421aabce0b52b2f565a6b540'
+# AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
+# bleeding-edge branch here when one is ready and verified.
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '3cda64eeb2fd1c1677d937cd724aa52b98b62617'

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -18,8 +18,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 98678b39d17be1fd421aabce0b52b2f565a6b540
-  ref: 98678b39d17be1fd421aabce0b52b2f565a6b540
+  revision: 3cda64eeb2fd1c1677d937cd724aa52b98b62617
+  ref: 3cda64eeb2fd1c1677d937cd724aa52b98b62617
   specs:
     au_ps_inferno (0.0.1)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf
-  ref: 7dce73a0cd35fcc4ba84b15526f1b3345a9c9aaf
+  revision: 3cda64eeb2fd1c1677d937cd724aa52b98b62617
+  ref: 3cda64eeb2fd1c1677d937cd724aa52b98b62617
   specs:
     au_ps_inferno (0.0.1)
       inferno_core (~> 1.0.6)


### PR DESCRIPTION
Part of #68 (Phase 1.5). Carries the AU PS `noEcosystem` validator perf fix (hl7au/au-ps-inferno#84) into **both** environments by pointing the au_ps ref at ps `master` (`3cda64e`):

- **prod** — base `Gemfile` + `Gemfile.lock`
- **dev** — `Gemfile.dev` + `Gemfile.dev.lock` (also drops the unverified `improve-test-text-and-ui` MS-conformance work from dev; re-point to a fresh bleeding-edge branch when ready)

Both lock changes are limited to the au_ps revision (conservative relock — no unrelated transitive bumps); both frozen checks pass. Reaches prod on the next `development → master` merge.