### PR TITLE
Merge master prod hotfixes into development (reconcile before prod ship)

### DIFF
--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       containers:
       - name: inferno-worker
         image: {{ .Values.inferno.imageUrl }}

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       volumes:
         - name: examplenginx-config
           configMap:

--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -15,9 +15,10 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # avoid spot reclamation taking the single-replica job queue down mid-run
       containers:
       - name: redis
-        image: redis:7.0.5-bullseye
+        image: redis:8.2-alpine
         imagePullPolicy: Always
         ports:
           - containerPort: 6379

--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1 # need clustering for multiple replicas
+  strategy:
+    type: Recreate   # single-replica + RWO EBS PVC: terminate old before new to avoid Multi-Attach deadlock
   selector:
     matchLabels:
       app: inferno-redis

--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -42,7 +42,10 @@ spec:
             cpu: "1000m"
           limits:
             memory: "12Gi"
-            cpu: "2000m"
+            cpu: "3000m"   # raised from 2000m for burst headroom (validations are CPU-bound and starved
+                           # the health endpoint). Request stays 1000m: scheduling is memory-driven (10Gi)
+                           # onto 2-4 vCPU r-family nodes, so this is a burst ceiling under a 4-vCPU node's
+                           # ~3920m allocatable, leaving room for node DaemonSets/kubelet.
         startupProbe:
           httpGet:
             path: /
@@ -66,8 +69,10 @@ spec:
             port: 3500
           initialDelaySeconds: 60
           periodSeconds: 30
-          timeoutSeconds: 10      # Increased from 5s - preset loading can block briefly
-          failureThreshold: 5     # Increased from 3 - allows 150s (5*30) before restart
+          timeoutSeconds: 30      # baseEngine generateSnapshot() saturates Ktor threads; a single
+                                  # validation can run ~160s and block the health endpoint
+          failureThreshold: 10    # allows 300s (10*30) before restart - covers a full validation/preset
+                                  # load so a busy (not wedged) validator is not killed mid-session
   volumeClaimTemplates:
   - metadata:
       name: fhir-package-cache

--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         fsGroup: 1000  # Ensures volumes are writable by ktor user (UID 1000)
       nodeSelector:
         kubernetes.io/arch: amd64
+        karpenter.sh/capacity-type: on-demand  # prod: avoid spot-reclamation churn disrupting test runs (redis already pinned)
       containers:
       - name: validator-api
         image: {{ .Values.inferno.validatorImageUri }}


### PR DESCRIPTION
Back-merges the **8 prod-only commits** on `master` (on-demand node pinning, redis 8.2-alpine + Recreate strategy, validator liveness/CPU tuning) into `development`, so development fully contains master and the upcoming `development → master` ship is a clean merge.

One conflict — `validator-api.statefulset.yaml` — resolved as the **union** of both sides:
- master: `karpenter.sh/capacity-type: on-demand` nodeSelector + CPU limit `3000m` + liveness `timeout 30s / threshold 10`
- development: validator-presets configMap volume + `VALIDATION_SERVICE_PRESETS_FILE_PATH` env + mount

(Both sides already set the same liveness values.) Other 3 files auto-merged. `helm template` renders cleanly (19 resources).

Note: the on-demand pinning / CPU / liveness tuning now also apply to **dev** (shared templates), which is fine — they're improvements. Part of #68.