### PR TITLE
feat: gate performance monitoring (dev-only feature flag)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,6 +3,7 @@ INFERNO_HOST=https://development.inferno.sparked-fhir.com
 VALIDATOR_URL=http://validator_service:4567
 REDIS_URL=redis://redis:6379/0
 BASE_PATH=suites
+PERFORMANCE_MONITORING_ENABLED=true
 
 
 # JS_HOST=""

--- a/Rakefile
+++ b/Rakefile
@@ -24,20 +24,23 @@ namespace :db do
     require 'inferno/utils/migration'
     Inferno::Utils::Migration.new.run
 
-    # Run local migrations (separate schema version table to avoid collisions)
-    require 'sequel'
-    local_dir = File.join(__dir__, 'db', 'migrate')
-    if File.directory?(local_dir) && !Dir.glob("#{local_dir}/*.rb").empty?
-      db = Sequel.connect(
-        adapter:  'postgres',
-        host:     ENV.fetch('POSTGRES_HOST', 'localhost'),
-        port:     ENV.fetch('POSTGRES_PORT', '5432').to_i,
-        database: ENV.fetch('POSTGRES_DB', 'inferno'),
-        user:     ENV.fetch('POSTGRES_USER', 'postgres'),
-        password: ENV.fetch('POSTGRES_PASSWORD', '')
-      )
-      Sequel::Migrator.run(db, local_dir, table: :local_schema_migrations)
-      db.disconnect
+    # Local migrations are dev-only (performance monitoring schema); gated by
+    # PERFORMANCE_MONITORING_ENABLED so prod's database schema is left untouched.
+    if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
+      require 'sequel'
+      local_dir = File.join(__dir__, 'db', 'migrate')
+      if File.directory?(local_dir) && !Dir.glob("#{local_dir}/*.rb").empty?
+        db = Sequel.connect(
+          adapter:  'postgres',
+          host:     ENV.fetch('POSTGRES_HOST', 'localhost'),
+          port:     ENV.fetch('POSTGRES_PORT', '5432').to_i,
+          database: ENV.fetch('POSTGRES_DB', 'inferno'),
+          user:     ENV.fetch('POSTGRES_USER', 'postgres'),
+          password: ENV.fetch('POSTGRES_PASSWORD', '')
+        )
+        Sequel::Migrator.run(db, local_dir, table: :local_schema_migrations)
+        db.disconnect
+      end
     end
   end
 end

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
         condition: service_healthy
     environment:
       FHIR_RESOURCE_VALIDATOR_URL: http://validator-api:3500
+      PERFORMANCE_MONITORING_ENABLED: "true"
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_DB: inferno

--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,15 @@
 require 'inferno'
 require_relative 'lib/inferno_platform_template/patches'
-require_relative 'lib/inferno_platform_template/request_timing'
-require_relative 'lib/inferno_platform_template/validator_timing'
-require_relative 'lib/inferno_platform_template/performance_app'
+
+# Performance monitoring (request/validator timing + the /performance page) is dev-only,
+# gated by PERFORMANCE_MONITORING_ENABLED. Kept off in prod so the timing middleware —
+# which writes to columns created only by the dev-only local migration — is never loaded.
+PERFORMANCE_MONITORING = ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
+if PERFORMANCE_MONITORING
+  require_relative 'lib/inferno_platform_template/request_timing'
+  require_relative 'lib/inferno_platform_template/validator_timing'
+  require_relative 'lib/inferno_platform_template/performance_app'
+end
 
 use Rack::Static,
     urls: Inferno::Utils::StaticAssets.static_assets_map,
@@ -12,8 +19,12 @@ Inferno::Application.finalize!
 
 use Inferno::Utils::Middleware::RequestLogger
 
-run Rack::URLMap.new(
-  '/api/performance' => InfernoPlatformTemplate::PerformanceApp.new,
-  '/performance'     => InfernoPlatformTemplate::PerformanceApp.new,
-  '/'                => Inferno::Web.app
-)
+if PERFORMANCE_MONITORING
+  run Rack::URLMap.new(
+    '/api/performance' => InfernoPlatformTemplate::PerformanceApp.new,
+    '/performance'     => InfernoPlatformTemplate::PerformanceApp.new,
+    '/'                => Inferno::Web.app
+  )
+else
+  run Inferno::Web.app
+end

--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -7,3 +7,4 @@ data:
   FHIR_RESOURCE_VALIDATOR_URL: {{ default "http://validator-api:3500" .Values.inferno.externalValidatorUrl | quote }}
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}
   RAILS_ENV: {{ default "production" .Values.inferno.railsEnv | quote }}
+  PERFORMANCE_MONITORING_ENABLED: {{ .Values.inferno.performanceMonitoring | default false | quote }}

--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -8,6 +8,7 @@ inferno:
   validatorImageUri: markiantorno/validator-wrapper:latest
   replicas: 1
   workerReplicas: 1
+  performanceMonitoring: true
 
 validator:
   replicas: 1

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -15,6 +15,9 @@ inferno:
   terminologyServer: "https://tx.dev.hl7.org.au/fhir"
   externalValidatorUrl: null  # This can be overridden during chart deployment
   validatorImageUri: "markiantorno/validator-wrapper:1.0.68"
+  # Performance monitoring (request/validator timing + /performance page + its DB
+  # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
+  performanceMonitoring: false
 
 validator:
   storageClassName: "gp3-encrypted"  # Use default EBS storage class for validator caches

--- a/worker.rb
+++ b/worker.rb
@@ -3,8 +3,12 @@ require 'sidekiq-cron'
 
 require_relative 'lib/inferno_platform_template/delete_old_sessions'
 require_relative 'lib/inferno_platform_template/patches'
-require_relative 'lib/inferno_platform_template/request_timing'
-require_relative 'lib/inferno_platform_template/validator_timing'
+
+# Performance monitoring timing middleware is dev-only (see config.ru).
+if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
+  require_relative 'lib/inferno_platform_template/request_timing'
+  require_relative 'lib/inferno_platform_template/validator_timing'
+end
 
 # Configure OpenTelemetry for inferno-worker spans.
 # Env vars set by the Helm chart:


### PR DESCRIPTION
Part of #68. Makes the performance page + request/validator timing + its DB migration a **config-gated, dev-only** feature, so the Phase 1 prod ship (#79) doesn't drag it into prod — and it can be turned on in prod later by flipping one value (deploy ≠ release).

## Gating (`PERFORMANCE_MONITORING_ENABLED`)
- **config.ru** — timing middleware + `/performance` mount load only when enabled; otherwise the plain `Inferno::Web.app`. `patches.rb` stays **ungated** (it's the `MSChecker` compat fix required by au_core ≥ 1.4.1, not perf).
- **worker.rb** — timing middleware gated; OTel + `delete_old_sessions` kept.
- **Rakefile** — the local (perf) DB migration runs only when enabled, so **prod's schema is untouched**; the Inferno core migration still always runs.
- **inferno ConfigMap** — `PERFORMANCE_MONITORING_ENABLED` from `.Values.inferno.performanceMonitoring` (default **false**); feeds app, worker, and the migration initContainer.

## Per-env
- `values.yaml`: **off** by default → prod off. `values-dev.yaml`: **on**. Local dev on via `.env.development` + compose worker.
- Verified: `helm template` renders `"true"` for dev, `"false"` for prod.

## Effect
Once merged to `development`, **#79 will include this**, so the prod ship carries the perf code **dark** (no page, no timing, no schema change). Dev keeps it fully working. To enable in prod later: set `performanceMonitoring: true` in `values-prod.yaml`.