### PR TITLE
ci: skip image build on config-only pushes (fix promote rebuild loop)

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -5,6 +5,15 @@ on:
     branches:
       - master
       - development
+    # Only rebuild the image when image-affecting source changes. Config-only pushes
+    # (helm/values image-tag promotions, docs) must NOT rebuild: promotion re-points to
+    # an already-built image ("build once, deploy many"), and rebuilding would re-fire
+    # the prod-promotion step and spawn another promote branch (loop). web/ is NOT
+    # ignored — it's baked into the static site / nginx image.
+    paths-ignore:
+      - 'infra/**'
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches:
       - master

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,10 @@
 
 eval_gemfile 'Gemfile.common'
 
-# Released AU Core test kit (published on RubyGems by hl7au).
-# NOTE: the newest published version is 1.4.0; code on the kit's master is ahead
-# (1.4.2, unreleased). Once 1.4.2 is tagged + released, bump this to '~> 1.4'.
+# Released AU Core test kit (published on RubyGems by hl7au). '~> 1.4.0' means
+# >= 1.4.0, < 1.5.0; Gemfile.lock pins the exact version (currently 1.4.2). Bump the
+# lock (bundle update au_core_test_kit) to adopt new 1.4.x releases; widen to '~> 1.4'
+# only if you want 1.5+ automatically.
 gem 'au_core_test_kit', '~> 1.4.0'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit on master


### PR DESCRIPTION
Part of #68. Fixes the soft loop where merging a prod-promotion PR re-triggered the build.

## Why
A promotion is a **CD/config event** (re-point prod to an already-built image), not a code change. But merging the promote PR is a push to `master`, which re-fired the build → rebuilt identical code → pushed another `promote/prod-<sha>` branch. Build-once-deploy-many says: don't rebuild on a config-only change.

## Fix
`paths-ignore: [infra/**, docs/**, *.md]` on the build's `push` trigger — config/docs-only pushes skip the build (and thus the promotion step), so promotions no longer loop. `web/` is intentionally **not** ignored (it's baked into the static site / nginx image), and mixed code+config pushes still build.

This respects the existing CI-write-back ADR (the fuller config/image-ref separation is Phase-3 territory).

## Also
Refreshes the stale `au_core_test_kit` Gemfile comment — 1.4.2 is now released; `~> 1.4.0` already permits it and the lock pins the exact version. (Comment only; `gem` line unchanged.)

Validated: workflow YAML parses.