### PR TITLE
refactor(helm): unify namespacing on .Release.Namespace (preview-env prep)

### DIFF
--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: inferno
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   FHIR_RESOURCE_VALIDATOR_URL: {{ default "http://validator-api:3500" .Values.inferno.externalValidatorUrl | quote }}
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}

--- a/infra/helm/inferno/templates/configs/inferno-httproute.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-httproute.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: inferno-route
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
     - name: main-gateway

--- a/infra/helm/inferno/templates/configs/inferno-redirect-httproute.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-redirect-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: inferno-redirect-route
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
     - name: main-gateway

--- a/infra/helm/inferno/templates/configs/redirect-nginx-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/redirect-nginx-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redirect-nginx-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   default.conf: |
     server {

--- a/infra/helm/inferno/templates/configs/validator-presets-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/validator-presets-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: validator-presets
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   presets.json: |
     [

--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-worker
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:

--- a/infra/helm/inferno/templates/deployments/inferno.hpa.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: inferno-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/infra/helm/inferno/templates/deployments/nginx.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/nginx.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.inferno.replicas | default 2 }}
   selector:

--- a/infra/helm/inferno/templates/deployments/redirect.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redirect.deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redirect-nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redirect-nginx
 spec:

--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1 # need clustering for multiple replicas
   strategy:

--- a/infra/helm/inferno/templates/redis.pvc.yaml
+++ b/infra/helm/inferno/templates/redis.pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redis-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/infra/helm/inferno/templates/services/inferno.service.yaml
+++ b/infra/helm/inferno/templates/services/inferno.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inferno
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/infra/helm/inferno/templates/services/nginx.service.yaml
+++ b/infra/helm/inferno/templates/services/nginx.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/infra/helm/inferno/templates/services/redirect.service.yaml
+++ b/infra/helm/inferno/templates/services/redirect.service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redirect-nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redirect-nginx
 spec:

--- a/infra/helm/inferno/templates/services/redis.service.yaml
+++ b/infra/helm/inferno/templates/services/redis.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inferno-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   ports:

--- a/infra/helm/inferno/templates/services/validator-api.service.yaml
+++ b/infra/helm/inferno/templates/services/validator-api.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   sessionAffinity: ClientIP

--- a/infra/helm/inferno/templates/statefulsets/validator-api.hpa.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: validator-api  # Required for StatefulSet
   replicas: {{ .Values.validator.replicas | default 2 }}


### PR DESCRIPTION
Part of #68 (Phase 2, PR 1/4). Makes the chart render into **any** namespace so per-PR preview envs (`inferno-pr-N`) work.

## What
Replaces `{{ .Values.namespace }}` with `{{ .Release.Namespace }}` across all 19 template namespace fields (the chart was inconsistent — secrets/configmaps already used `.Release.Namespace`, everything else used `.Values.namespace`). The ArgoCD **destination namespace** now drives every resource, so the chart needs no `namespace` value at all.

## Verified (helm template)
- dev → all resources in `dev-inferno` (unchanged)
- prod → all in `prod-inferno` (was relying on ArgoCD injecting it into blank `namespace:` fields — now explicit)
- a fresh `--namespace inferno-pr-1` → all in `inferno-pr-1` ✓
- no blank namespaces

## Follow-ups (later Phase 2 PRs, in sparked-argo)
- Remove the now-dead inline `namespace: dev-inferno` helm override in `inferno-dev.yaml`.
- DNS-01 wildcard cert/listener, loosen `proj-inferno` AppProject, PR-generator ApplicationSet (labelled `preview` + ephemeral Postgres).

No app-image rebuild (helm-only change; the build skips `infra/**` per #82).