### PR TITLE
fix(chart): point preview in-namespace Postgres at bitnamilegacy archive

### DIFF
--- a/docs/preview-smoke-test.md
+++ b/docs/preview-smoke-test.md
@@ -1,0 +1,4 @@
+# Preview environment smoke test
+
+Throwaway marker to exercise the Phase 2 per-PR preview loop end-to-end
+(build → ApplicationSet → deploy → teardown). Safe to delete with its PR.

--- a/docs/preview-smoke-test.md
+++ b/docs/preview-smoke-test.md
@@ -1,4 +1,0 @@
-# Preview environment smoke test
-
-Throwaway marker to exercise the Phase 2 per-PR preview loop end-to-end
-(build → ApplicationSet → deploy → teardown). Safe to delete with its PR.

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -44,6 +44,14 @@ validatorAutoscaling:
 postgresql:
   enabled: false # enable if not using rds from aws-impl
   externaldbhost: null # This can be overridden during chart deployment
+  # Bitnami purged versioned tags from docker.io/bitnami (mid-2025) and moved them
+  # to the bitnamilegacy archive, so the subchart's pinned default tag 404s. Point
+  # the in-namespace Postgres (preview envs only — dev/prod use RDS) at the archive.
+  # Stopgap: bitnamilegacy receives no updates and will eventually be removed; revisit
+  # by bumping/replacing the postgresql subchart.
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
   containerPorts:
     postgresql: 5432
   global:


### PR DESCRIPTION
The vendored `postgresql` subchart pins `docker.io/bitnami/postgresql:16.3.0-debian-12-r19`, which Bitnami **removed** from Docker Hub in mid-2025 (moved to the `bitnamilegacy` archive). The ephemeral in-namespace Postgres used by preview environments (`postgresql.enabled=true`) therefore fails with `ImagePullBackOff: not found`.

Surfaced by the first live preview (`inferno-pr-85`): app/redis/worker/nginx/validator all scheduled, but `…-postgresql-0` couldn't pull its image.

Fix: override `postgresql.image.repository` → `bitnamilegacy/postgresql` in the chart `values.yaml`. dev/prod use external RDS (`postgresql.enabled=false`) so no bitnami image renders there — verified.

Stopgap: `bitnamilegacy` is an unmaintained archive that will eventually be removed; follow-up is to bump/replace the postgresql subchart.

(This PR doubles as the end-to-end preview validation — it carries the `preview` label, so `inferno-pr-85` rebuilds on this commit and should come up fully with a working DB.)