### PR TITLE
feat(preview): sticky PR comment linking to the preview environment

### DIFF
--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -1,0 +1,86 @@
+name: Preview environment PR comment
+
+# Posts (and keeps updated) a single sticky comment on a PR that carries the
+# `preview` label, pointing at its ephemeral preview environment. Polls the URL
+# and flips the comment to "live" once it serves, and notes teardown when the
+# label is removed or the PR closes. The env itself is created by the sparked-argo
+# `inferno-previews` ApplicationSet — this workflow is purely the PR-side notice.
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+# Don't stack poll jobs if the label is toggled repeatedly on one PR.
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Only react to the `preview` label (added/removed) or to a labelled PR closing.
+    if: >-
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name == 'preview') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Upsert preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const n = context.payload.pull_request.number;
+            const host = `pr-${n}.preview.inferno.sparked-fhir.com`;
+            const url = `https://${host}`;
+            const marker = '<!-- inferno-preview-env -->';
+            const action = context.payload.action;
+
+            async function upsert(body) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: n, per_page: 100,
+              });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: `${marker}\n${body}` });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: n, body: `${marker}\n${body}` });
+              }
+            }
+
+            // Label removed or PR closed -> note teardown and stop.
+            if (action !== 'labeled') {
+              await upsert(`### 🧹 Preview environment torn down\n\n\`${host}\` has been removed.`);
+              return;
+            }
+
+            await upsert(
+              `### 🚀 Preview environment\n\nProvisioning at **${url}** — building this PR's image and syncing via ArgoCD. ` +
+              `Usually live within a few minutes; new commits update it automatically. ` +
+              `Remove the \`preview\` label or close the PR to tear it down.`
+            );
+
+            // Poll until it serves (image build + ArgoCD sync + validator warmup).
+            const deadline = Date.now() + 12 * 60 * 1000;
+            let live = false;
+            while (Date.now() < deadline) {
+              await new Promise(r => setTimeout(r, 20000));
+              try {
+                const res = await fetch(url, { redirect: 'manual' });
+                if (res.status >= 200 && res.status < 400) { live = true; break; }
+              } catch (e) { /* DNS/connection not ready yet */ }
+            }
+
+            if (live) {
+              await upsert(
+                `### ✅ Preview environment live\n\n**${url}**\n\n` +
+                `Running this PR's image. New commits update it; remove the \`preview\` label or close the PR to tear it down.`
+              );
+            } else {
+              await upsert(
+                `### ⏳ Preview environment still provisioning\n\n**${url}** is taking longer than usual ` +
+                `(image build + validator warmup can take ~10 min). It should come up shortly.`
+              );
+            }


### PR DESCRIPTION
Adds `.github/workflows/preview-comment.yaml`. When a PR gains the `preview` label it posts a single sticky comment with the env URL (`https://pr-<n>.preview.inferno.sparked-fhir.com`), polls until it serves (~image build + ArgoCD sync + validator warmup), and flips the comment to **✅ live**. Removing the label or closing the PR updates it to a teardown notice.

Standard preview-env UX (à la Vercel/Netlify), but the env is owned by the sparked-argo `inferno-previews` ApplicationSet — this workflow is only the PR-side notice. Uses first-party `actions/github-script`; `pull-requests/issues: write` only.

Note on access control: only Triage+/Write collaborators can apply labels and fork PRs can't push images, so the `preview` label is already the access gate — no extra guard added here.