### PR TITLE
fix(chart): manage preview Namespace so teardown prunes it

### DIFF
--- a/infra/helm/inferno/templates/namespace.yaml
+++ b/infra/helm/inferno/templates/namespace.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.createNamespace }}
+# Preview environments only. When ArgoCD renders the Namespace as a managed resource,
+# the Application's resources-finalizer prunes it on deletion (PR closed / `preview`
+# label removed) — so teardown removes the namespace itself, not just its contents.
+# ArgoCD's CreateNamespace=true sync option creates a namespace it does NOT track, so
+# without this the empty namespace would linger after teardown.
+#
+# dev/prod leave this false and target their pre-existing namespaces — templating a
+# Namespace there would make ArgoCD try to adopt and (on app deletion) delete them.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+{{- end }}

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -1,3 +1,8 @@
+# Render the destination Namespace as a managed resource so ArgoCD prunes it on
+# teardown. Preview environments set this true; dev/prod leave it false and use their
+# pre-existing namespaces. See templates/namespace.yaml.
+createNamespace: false
+
 ingress:
   hostnames:
     - example.inferno.sparked-fhir.com


### PR DESCRIPTION
**Problem found during the #85 teardown test:** closing a preview PR deletes the Application and prunes all workloads (no pods/compute left), but the `inferno-pr-<n>` **namespace lingers empty**. ArgoCD's `CreateNamespace=true` sync option creates a namespace it doesn't track, so the `resources-finalizer` never removes it. Over many PRs you'd accumulate empty namespaces.

**Fix:** render the destination Namespace as a managed resource, gated behind a new `createNamespace` value (default `false`). Then ArgoCD tracks it and prunes it on Application deletion → full teardown.

- Preview envs set `createNamespace=true` (companion sparked-argo PR adds it to the `inferno-previews` ApplicationSet values).
- dev/prod leave it `false` and keep using their pre-existing namespaces — templating one there would make ArgoCD try to adopt and (on app deletion) **delete** `dev-inferno`/`prod-inferno`. Verified both render **zero** Namespace resources.

Pairs with hl7au/au-fhir-inferno (preview ApplicationSet) and depends on the companion sparked-argo PR to take effect.