### PR TITLE
test: preview teardown re-check (throwaway)

### DIFF
--- a/docs/preview-teardown-check.md
+++ b/docs/preview-teardown-check.md
@@ -1,0 +1,3 @@
+# Preview teardown check
+
+Throwaway marker to confirm full namespace teardown (#87/#38) on a live preview. Delete with its PR.


### PR DESCRIPTION
Throwaway PR to confirm the namespace fully prunes on teardown now that #87/#38 are live. Will be closed once verified.