### PR TITLE
ci: add quality-control PR gate

### DIFF
--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -1,0 +1,74 @@
+name: quality-control
+
+# PR gate for au-fhir-inferno. Advisory until branch protection requires it (Track B
+# in docs/cicd-overhaul-plan.md — needs repo admin). Runs the existing RSpec suite,
+# proves both dependency sets resolve frozen, that the static site still generates, and
+# that the Helm chart renders for dev / prod / preview.
+on:
+  pull_request:
+    branches: [master, development]
+  push:
+    branches: [master, development]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-control-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Fail if the committed lockfile doesn't match the Gemfile (no implicit updates).
+  BUNDLE_FROZEN: "true"
+
+jobs:
+  quality-control:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby (installs the prod Gemfile, frozen)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: true
+
+      - name: RSpec
+        env:
+          APP_ENV: test   # config/database.yml test = sqlite :memory: — no DB service needed
+        run: bundle exec rake spec
+
+      - name: Static site generates (Jekyll)
+        run: |
+          cp .env.development .env
+          bundle exec rake web:generate_dev
+
+      - name: Dev dependency set resolves (Gemfile.dev, frozen)
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
+        run: bundle install
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm chart renders (dev / prod / preview)
+        working-directory: infra/helm/inferno
+        run: |
+          echo "::group::dev"
+          helm template inferno . -n inferno-dev -f values-dev.yaml > /dev/null
+          echo "::endgroup::"
+          echo "::group::prod"
+          helm template inferno . -n inferno -f values-prod.yaml > /dev/null
+          echo "::endgroup::"
+          echo "::group::preview"
+          helm template inferno-pr-0 . -n inferno-pr-0 \
+            --set createNamespace=true \
+            --set postgresql.enabled=true \
+            --set externalSecrets.enabled=false \
+            --set 'postgresql.externaldbhost=' \
+            --set autoscaling.enabled=false \
+            --set inferno.imageUrl=ghcr.io/hl7au/au-fhir-inferno:ci-pr \
+            --set nginx.platformImageUri=ghcr.io/hl7au/au-fhir-inferno:ci-nginx-pr \
+            --set 'ingress.hostnames[0]=pr-0.preview.inferno.sparked-fhir.com' > /dev/null
+          echo "::endgroup::"

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -34,20 +34,15 @@ jobs:
           ruby-version: '3.3.6'
           bundler-cache: true
 
-      - name: RSpec
+      - name: Dev dependency set resolves (Gemfile.dev, frozen)
         env:
-          APP_ENV: test   # config/database.yml test = sqlite :memory: — no DB service needed
-        run: bundle exec rake spec
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
+        run: bundle install
 
       - name: Static site generates (Jekyll)
         run: |
           cp .env.development .env
           bundle exec rake web:generate_dev
-
-      - name: Dev dependency set resolves (Gemfile.dev, frozen)
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
-        run: bundle install
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -72,3 +67,10 @@ jobs:
             --set nginx.platformImageUri=ghcr.io/hl7au/au-fhir-inferno:ci-nginx-pr \
             --set 'ingress.hostnames[0]=pr-0.preview.inferno.sparked-fhir.com' > /dev/null
           echo "::endgroup::"
+
+      # Boots the full Inferno app (spec_helper → migrations on sqlite :memory:), so it's
+      # the heaviest check — run last so the deterministic checks above always report.
+      - name: RSpec
+        env:
+          APP_ENV: test
+        run: bundle exec rake spec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--color


### PR DESCRIPTION
Adds `.github/workflows/quality-control.yaml`, the PR gate the plan + CODEOWNERS already assume but which didn't exist — today a PR can break the specs or the build and merge cleanly.

**Checks** (all offline / no services, verified locally):
- **RSpec** — `config/database.yml` test env is sqlite `:memory:`, so no Postgres service needed.
- **Frozen dependency resolve** — `Gemfile` (via bundler-cache) and `Gemfile.dev` (explicit) must match their committed locks; guards the lock-drift area Phase 1 fixed.
- **Static site generates** — `rake web:generate_dev` (Jekyll); the highest-value 'does it still build' smoke.
- **Helm chart renders** — dev / prod / preview; would have caught the `POSTGRES_HOST` quoting and `bitnamilegacy` chart bugs pre-merge.

**Advisory for now** — making `quality-control` a *required* check needs repo admin (Track B; requested from Brett). Deliberately omits a 'Gemfile has no git refs' guard: the prod `Gemfile` legitimately pins `au_ps_inferno` by git SHA until AU PS can be released to RubyGems.

This PR triggers the workflow on itself — see its checks.