### PR TITLE
docs: Phase 3 trunk-cutover runbook (+ proposed trunk workflow)

### DIFF
--- a/docs/phase3-trunk-cutover.md
+++ b/docs/phase3-trunk-cutover.md
@@ -1,0 +1,135 @@
+# Phase 3 — Trunk cutover runbook
+
+Status: **draft / not yet executed** · Owner: Kyle Pettigrew · Drafted: 2026-06-23
+
+The design + step-by-step checklist for collapsing the two long-lived branches into a
+single trunk. This document is reviewed and merged first; **execution happens in a
+separate, deliberate session** (low prod traffic) using the checklist below.
+
+> **Scope correction vs the original roadmap.** The roadmap said "collapse
+> development + master → `main`". On review, the rename is **cosmetic** — trunk-based
+> development is about having *one* long-lived branch, not its name. Renaming would force
+> a default-branch switch (**admin-only**) and re-point every clone for no functional
+> gain. So **the trunk stays `master`**, and Phase 3 carries **no hard admin dependency**
+> — branch protection is a fast-follow, not a gate (see below).
+
+---
+
+## Goal / end state
+
+One trunk. Feature work flows: **branch → PR → `master` → auto-deploy to staging →
+promotion PR → prod.**
+
+- `master` = trunk. `development` retired.
+- Every push to `master`: build **one** image `:<sha>`, auto-deploy it to staging, and
+  open a prod-promotion PR for the *same* image (build once, deploy many).
+- **Staging** = the env currently at `development.inferno.sparked-fhir.com`
+  (conceptually re-labelled; hostname unchanged), now a **prod mirror** (released-flavour).
+- **Prod** = promotion PR (human gate), shipping the identical `:<sha>` artifact staging
+  already ran.
+- **Bleeding-edge / unreleased kit commits** live in **preview environments**
+  (Gemfile.dev), not in a persistent branch. Previews are unchanged.
+
+---
+
+## Why no admin is required (and the protection nuance)
+
+- No rename → no default-branch change → **no admin action to cut over.**
+- We can do every cutover step with `maintain` on au-fhir-inferno + our admin on
+  `aehrc/sparked-argo`.
+- **Branch protection is not a blocker.** `master` has none today, so going trunk is *not
+  less* protected — same (zero) enforcement. It's a fast-follow ask to Brett, not a gate.
+- Honest nuance: protection is *more valuable* under trunk, because today the
+  `development → master` merge is an implicit human checkpoint that disappears. Mitigations
+  that hold without protection: **prod keeps its human gate** (you merge the promotion PR),
+  and **`quality-control` already runs on pushes to `master`** (advisory signal). So add
+  protection soon — but it doesn't block the cutover.
+
+---
+
+## Decisions to confirm (defaults baked; adjust in review)
+
+1. **Trunk = `master`, no rename.** *(recommended)*
+2. **Build once, prod-flavour trunk — THE consequential decision.** `master` builds a
+   single released-flavour image (`Gemfile` + `web:generate_prod`); **staging and prod run
+   the same artifact.** Bleeding-edge (Gemfile.dev / unreleased kit SHAs) moves to preview
+   envs. *Alternative:* keep building two flavours (staging = bleeding-edge, prod =
+   released) — but then staging ≠ the artifact you promote, which throws away a core trunk
+   benefit. **Recommended: build once.** This also makes `Gemfile.dev`'s only job "preview
+   override", matching the earlier decision.
+3. **Staging deploys automatically via the existing image write-back** (repointed to
+   `master` + `values-dev.yaml`, `[skip ci]`; `infra/**` is paths-ignored so no rebuild
+   loop). *(recommended)*
+   > Corrects an earlier suggestion of "promotion-PR for staging": a promotion PR isn't
+   > *auto*, and the roadmap wants staging to auto-track the trunk. Retiring the write-back
+   > entirely (ArgoCD Image Updater) is a clean **future** improvement, not part of the cutover.
+4. **Prod = promotion PR** (unchanged human release gate).
+5. **`Gemfile.dev` = preview-override only.** Trunk `Gemfile` stays released-form (`au_ps`
+   remains git-SHA-pinned until it can publish to RubyGems). The "trunk Gemfile is
+   git-ref-free" guard is **deferred** until AU PS releases.
+6. **Keep filenames / ArgoCD app names** (`values-dev.yaml`, `inferno-dev` Application) to
+   minimise churn; re-label to "staging" conceptually. Optional rename later.
+7. **Branch protection on `master`** (require PR + 1 review + passing `quality-control`) =
+   fast-follow ask to Brett.
+
+---
+
+## Cutover steps
+
+Legend: **[us]** = doable with current access · **[Brett]** = admin, fast-follow.
+
+1. **[us] Bring `master` current.** Final `development → master` merge **commit** (never
+   squash — preserves ancestry). Confirm `quality-control` is green on `master`.
+2. **[us] Swap in the trunk build workflow.** Replace
+   `.github/workflows/build-and-release-package.yaml` with the trunk version (drafted at
+   `docs/phase3/build-and-release-package.yaml`): drops the `development` trigger and the
+   dev-flavour trunk build; `master` builds `:<sha>` once, writes the staging tag back to
+   `values-dev.yaml`, and opens the prod-promotion PR. Preview path unchanged.
+3. **[us · sparked-argo] Repoint staging.** `inferno-dev` Application
+   `targetRevision: development → master`. (Prod already tracks `master`.)
+4. **[us] Smoke test.** Push a trivial commit to `master` → `:<sha>` builds → staging
+   (`development.inferno…`) auto-updates and is healthy → a prod-promotion PR appears (don't
+   merge unless actually releasing).
+5. **[us] Retire `development`.** Announce; stop deploying from it; **after** staging-from-
+   master is proven, delete the branch (keep an archived tag/ref for safety).
+6. **[Brett] Branch protection** ruleset on `master`: require PR + 1 review + passing
+   `quality-control`. *(fast-follow)*
+7. **[us] Tidy up.** Update docs / CODEOWNERS / PR template to trunk language; mark Phase 3
+   complete in `docs/cicd-overhaul-plan.md` + memory.
+
+---
+
+## Verification checklist
+
+- [ ] Staging serves the released-flavour build of the latest `master` commit.
+- [ ] Prod is untouched until a promotion PR is merged (and ships the same `:<sha>`).
+- [ ] Preview envs still spin up on a `preview`-labelled PR.
+- [ ] `quality-control` runs on pushes to `master`.
+- [ ] No rebuild loop from the staging write-back (`[skip ci]` + `infra/**` paths-ignore).
+
+---
+
+## Rollback
+
+Low-risk — `master` is never renamed or destroyed, and **prod stays human-gated
+throughout** (the promotion PR is the only path to prod), so prod cannot auto-break.
+
+1. Revert the workflow commit (restores the development/master split behaviour).
+2. Repoint the `inferno-dev` Application `targetRevision` back to `development`.
+3. `development` still exists (don't delete until proven) → resume as before.
+
+---
+
+## Handover — kickoff prompt for the execution session
+
+```
+Execute Phase 3 (trunk cutover) for AU Inferno. Read docs/phase3-trunk-cutover.md and
+memory `inferno-cicd-overhaul-roadmap` first. Trunk = master (no rename). Follow the
+"Cutover steps" checklist; the trunk build workflow is pre-drafted at
+docs/phase3/build-and-release-package.yaml. Confirm the "Decisions to confirm" defaults
+with me before step 2. Prod stays human-gated via the promotion PR — do not merge a
+promotion PR without my go. Do the development→master merge, swap the workflow, repoint
+the inferno-dev ArgoCD app (sparked-argo) to master, smoke-test staging, then retire
+development. Branch protection is Brett's fast-follow, not a blocker. Open PRs; verify
+each with helm template + watching ArgoCD sync.
+```

--- a/docs/phase3/build-and-release-package.yaml
+++ b/docs/phase3/build-and-release-package.yaml
@@ -1,0 +1,156 @@
+# ⚠️ PROPOSED — Phase 3 trunk version of build-and-release-package.yaml. NOT ACTIVE.
+# Lives under docs/phase3/ so it can be reviewed ahead of the cutover without running.
+# At cutover (step 2 of docs/phase3-trunk-cutover.md) this replaces
+# .github/workflows/build-and-release-package.yaml. Reflects the recommended decisions:
+# trunk = master, build once (released flavour) for staging + prod, staging auto-deploys
+# via write-back, prod via promotion PR, previews unchanged.
+name: Build and Release Inferno and Nginx Images
+
+on:
+  push:
+    branches:
+      - master            # the trunk
+    paths-ignore:         # config-only pushes (image-tag write-backs, docs) must not rebuild
+      - 'infra/**'
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    # Preview images for `preview`-labelled PRs (any base). PR quality gating lives in
+    # quality-control.yaml; this workflow's only PR job is building preview images.
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    # Build on: any push to the trunk; OR a PR carrying the `preview` label.
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set environment from event
+        id: config
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && \
+             [ "${{ contains(github.event.pull_request.labels.*.name, 'preview') }}" = "true" ]; then
+            # Preview: dev-flavoured (Gemfile.dev), tagged by PR head SHA.
+            echo "environment=pr" >> $GITHUB_OUTPUT
+            echo "rake_task=web:generate_dev" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile.dev" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "app_tag=${{ github.event.pull_request.head.sha }}-pr" >> $GITHUB_OUTPUT
+            echo "nginx_tag=${{ github.event.pull_request.head.sha }}-nginx-pr" >> $GITHUB_OUTPUT
+            echo "use_dev_env=true" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile.dev" >> $GITHUB_ENV
+          else
+            # Trunk (push to master): build ONCE, released flavour. Staging + prod run this
+            # same artifact (no -dev/-prod split — build once, deploy many).
+            echo "environment=trunk" >> $GITHUB_OUTPUT
+            echo "rake_task=web:generate_prod" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "app_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "nginx_tag=${{ github.sha }}-nginx" >> $GITHUB_OUTPUT
+            echo "use_dev_env=false" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Use dev environment file
+        if: steps.config.outputs.use_dev_env == 'true'
+        run: cp .env.development .env
+
+      - name: Generate static content
+        run: bundle exec rake ${{ steps.config.outputs.rake_task }}
+
+      - name: Log in to Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push app image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          build-args: |
+            BUNDLE_GEMFILE=${{ steps.config.outputs.bundle_gemfile }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}
+
+      - name: Build and push Nginx image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./nginx.Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}
+
+      # --- Trunk only (push to master): auto-deploy to staging + open prod promotion PR ---
+
+      # Staging auto-deploys: write the new tags into values-dev.yaml and commit back.
+      # [skip ci] + the infra/** paths-ignore above prevent a rebuild loop. ArgoCD
+      # (inferno-dev, targetRevision: master) syncs staging to the new image.
+      - name: Update staging image tags (values-dev.yaml)
+        if: github.event_name == 'push'
+        run: |
+          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}|" infra/helm/inferno/values-dev.yaml
+          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}|" infra/helm/inferno/values-dev.yaml
+
+      - name: Commit staging tags
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add infra/helm/inferno/values-dev.yaml
+          git commit -m "chore: deploy ${{ github.sha }} to staging [skip ci]"
+          git push origin master
+
+      # Prod promotion: push the SAME artifact's tags to a branch and surface a one-click
+      # PR link. Merging that PR = the prod release (human gate). ArgoCD (inferno-prod,
+      # targetRevision: master) syncs prod on merge.
+      - name: Push prod promotion branch
+        if: github.event_name == 'push'
+        run: |
+          BRANCH="promote/prod-${{ github.sha }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}|" infra/helm/inferno/values-prod.yaml
+          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}|" infra/helm/inferno/values-prod.yaml
+          git add infra/helm/inferno/values-prod.yaml
+          git commit -m "chore: promote prod to ${{ github.sha }}"
+          git push --force-with-lease origin "$BRANCH"
+          {
+            echo "## 🚀 Prod promotion ready"
+            echo ""
+            echo "Staging is already running this build. Merge to release it to prod:"
+            echo ""
+            echo "**https://github.com/${{ github.repository }}/compare/master...$BRANCH?expand=1**"
+            echo ""
+            echo "- app:   \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}\`"
+            echo "- nginx: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Drafts Phase 3 so execution becomes a checklist, not a design exercise. **Docs + an inert proposed workflow only — nothing is cut over by merging this.**

## Key reframing (from this session)
- **Trunk stays `master` — no rename.** Trunk-based dev is about having *one* long-lived branch, not its name. Renaming would force a default-branch switch (admin-only) for no functional gain.
- **Therefore no hard admin dependency.** Every cutover step is doable with `maintain` + our `sparked-argo` admin. **Branch protection is a fast-follow, not a gate** — `master` has none today, so going trunk is not *less* protected.

## What's in the PR
- `docs/phase3-trunk-cutover.md` — goal/end-state, decisions-to-confirm (defaults baked, flagged for review), ordered cutover steps tagged `[us]`/`[Brett]`, verification, rollback, and a kickoff prompt for the execution session.
- `docs/phase3/build-and-release-package.yaml` — the **proposed** trunk build workflow, staged under `docs/phase3/` so it's reviewable but **inert** (not under `.github/workflows/`). Replaces the active workflow at cutover step 2.

## Consequential decision flagged for you
**Build once, released-flavour trunk:** staging + prod run the *same* artifact; bleeding-edge moves to preview envs. The alternative (dual-flavour: staging bleeding-edge, prod released) means staging ≠ the artifact you promote. Recommended: build once. (Also corrects an earlier slip: staging deploys **auto via write-back**, not a promotion PR — a promotion PR isn't auto.)

Execution is intended for a **separate, focused session** (low prod traffic); prod stays human-gated via the promotion PR throughout, and rollback is low-risk since `master` is never renamed/destroyed.