### PR TITLE
Bring master current (development → master)

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -5,6 +5,15 @@ on:
     branches:
       - master
       - development
+    # Only rebuild the image when image-affecting source changes. Config-only pushes
+    # (helm/values image-tag promotions, docs) must NOT rebuild: promotion re-points to
+    # an already-built image ("build once, deploy many"), and rebuilding would re-fire
+    # the prod-promotion step and spawn another promote branch (loop). web/ is NOT
+    # ignored — it's baked into the static site / nginx image.
+    paths-ignore:
+      - 'infra/**'
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches:
       - master

--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -15,8 +15,13 @@ on:
       - 'docs/**'
       - '*.md'
   pull_request:
+    # `labeled` lets adding the `preview` label trigger a build; `synchronize` keeps the
+    # preview image tracking new commits on a labelled PR. Base may be master or
+    # development — the job `if` decides what actually builds (see below).
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
+      - development
 
 env:
   REGISTRY: ghcr.io
@@ -32,25 +37,52 @@ concurrency:
 jobs:
   build-and-push-images:
     runs-on: ubuntu-latest
+    # Build when: any push to master/development; OR a PR against master (existing
+    # build-check); OR any PR carrying the `preview` label (preview environments,
+    # regardless of base branch). A plain development PR with no `preview` label is
+    # skipped — it doesn't deploy anywhere, so there's nothing to build.
+    if: >-
+      github.event_name == 'push' ||
+      github.base_ref == 'master' ||
+      contains(github.event.pull_request.labels.*.name, 'preview')
     permissions:
       contents: write
       packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # For PR events build the PR's head commit (not the synthetic merge commit),
+          # so the image content matches the SHA we tag it with. Falls back to the
+          # pushed SHA for branch pushes.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Set environment from branch
+      - name: Set environment from event
         id: config
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/development" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && \
+             [ "${{ contains(github.event.pull_request.labels.*.name, 'preview') }}" = "true" ]; then
+            # Preview build: dev-flavoured (Gemfile.dev + dev static content), tagged by
+            # the PR head SHA so the sparked-argo ApplicationSet can deploy <sha>-pr.
+            echo "environment=pr" >> $GITHUB_OUTPUT
+            echo "rake_task=web:generate_dev" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile.dev" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "use_dev_env=true" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile.dev" >> $GITHUB_ENV
+          elif [ "$GITHUB_REF" = "refs/heads/development" ]; then
             echo "environment=dev" >> $GITHUB_OUTPUT
             echo "rake_task=web:generate_dev" >> $GITHUB_OUTPUT
             echo "bundle_gemfile=Gemfile.dev" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "use_dev_env=true" >> $GITHUB_OUTPUT
             echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile.dev" >> $GITHUB_ENV
           else
             echo "environment=prod" >> $GITHUB_OUTPUT
             echo "rake_task=web:generate_prod" >> $GITHUB_OUTPUT
             echo "bundle_gemfile=Gemfile" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "use_dev_env=false" >> $GITHUB_OUTPUT
             echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> $GITHUB_ENV
           fi
 
@@ -63,7 +95,7 @@ jobs:
         run: bundle install
 
       - name: Use dev environment file
-        if: github.ref == 'refs/heads/development'
+        if: steps.config.outputs.use_dev_env == 'true'
         run: cp .env.development .env
 
       - name: Generate static content
@@ -89,7 +121,7 @@ jobs:
           push: true
           build-args: |
             BUNDLE_GEMFILE=${{ steps.config.outputs.bundle_gemfile }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ steps.config.outputs.environment }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.image_sha }}-${{ steps.config.outputs.environment }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push Nginx image
@@ -98,7 +130,7 @@ jobs:
           context: .
           file: ./nginx.Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-nginx-${{ steps.config.outputs.environment }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.image_sha }}-nginx-${{ steps.config.outputs.environment }}
 
       - name: Update image tags in values-dev.yaml
         if: github.ref == 'refs/heads/development' && github.event_name == 'push'

--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -1,0 +1,86 @@
+name: Preview environment PR comment
+
+# Posts (and keeps updated) a single sticky comment on a PR that carries the
+# `preview` label, pointing at its ephemeral preview environment. Polls the URL
+# and flips the comment to "live" once it serves, and notes teardown when the
+# label is removed or the PR closes. The env itself is created by the sparked-argo
+# `inferno-previews` ApplicationSet — this workflow is purely the PR-side notice.
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+# Don't stack poll jobs if the label is toggled repeatedly on one PR.
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Only react to the `preview` label (added/removed) or to a labelled PR closing.
+    if: >-
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name == 'preview') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Upsert preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const n = context.payload.pull_request.number;
+            const host = `pr-${n}.preview.inferno.sparked-fhir.com`;
+            const url = `https://${host}`;
+            const marker = '<!-- inferno-preview-env -->';
+            const action = context.payload.action;
+
+            async function upsert(body) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: n, per_page: 100,
+              });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: `${marker}\n${body}` });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: n, body: `${marker}\n${body}` });
+              }
+            }
+
+            // Label removed or PR closed -> note teardown and stop.
+            if (action !== 'labeled') {
+              await upsert(`### 🧹 Preview environment torn down\n\n\`${host}\` has been removed.`);
+              return;
+            }
+
+            await upsert(
+              `### 🚀 Preview environment\n\nProvisioning at **${url}** — building this PR's image and syncing via ArgoCD. ` +
+              `Usually live within a few minutes; new commits update it automatically. ` +
+              `Remove the \`preview\` label or close the PR to tear it down.`
+            );
+
+            // Poll until it serves (image build + ArgoCD sync + validator warmup).
+            const deadline = Date.now() + 12 * 60 * 1000;
+            let live = false;
+            while (Date.now() < deadline) {
+              await new Promise(r => setTimeout(r, 20000));
+              try {
+                const res = await fetch(url, { redirect: 'manual' });
+                if (res.status >= 200 && res.status < 400) { live = true; break; }
+              } catch (e) { /* DNS/connection not ready yet */ }
+            }
+
+            if (live) {
+              await upsert(
+                `### ✅ Preview environment live\n\n**${url}**\n\n` +
+                `Running this PR's image. New commits update it; remove the \`preview\` label or close the PR to tear it down.`
+              );
+            } else {
+              await upsert(
+                `### ⏳ Preview environment still provisioning\n\n**${url}** is taking longer than usual ` +
+                `(image build + validator warmup can take ~10 min). It should come up shortly.`
+              );
+            }

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -1,0 +1,74 @@
+name: quality-control
+
+# PR gate for au-fhir-inferno. Advisory until branch protection requires it (Track B
+# in docs/cicd-overhaul-plan.md — needs repo admin). Runs the existing RSpec suite,
+# proves both dependency sets resolve frozen, that the static site still generates, and
+# that the Helm chart renders for dev / prod / preview.
+on:
+  pull_request:
+    branches: [master, development]
+  push:
+    branches: [master, development]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-control-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Fail if the committed lockfile doesn't match the Gemfile (no implicit updates).
+  BUNDLE_FROZEN: "true"
+
+jobs:
+  quality-control:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby (installs the prod Gemfile, frozen)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: true
+
+      - name: RSpec
+        env:
+          APP_ENV: test   # config/database.yml test = sqlite :memory: — no DB service needed
+        run: bundle exec rake spec
+
+      - name: Static site generates (Jekyll)
+        run: |
+          cp .env.development .env
+          bundle exec rake web:generate_dev
+
+      - name: Dev dependency set resolves (Gemfile.dev, frozen)
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
+        run: bundle install
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm chart renders (dev / prod / preview)
+        working-directory: infra/helm/inferno
+        run: |
+          echo "::group::dev"
+          helm template inferno . -n inferno-dev -f values-dev.yaml > /dev/null
+          echo "::endgroup::"
+          echo "::group::prod"
+          helm template inferno . -n inferno -f values-prod.yaml > /dev/null
+          echo "::endgroup::"
+          echo "::group::preview"
+          helm template inferno-pr-0 . -n inferno-pr-0 \
+            --set createNamespace=true \
+            --set postgresql.enabled=true \
+            --set externalSecrets.enabled=false \
+            --set 'postgresql.externaldbhost=' \
+            --set autoscaling.enabled=false \
+            --set inferno.imageUrl=ghcr.io/hl7au/au-fhir-inferno:ci-pr \
+            --set nginx.platformImageUri=ghcr.io/hl7au/au-fhir-inferno:ci-nginx-pr \
+            --set 'ingress.hostnames[0]=pr-0.preview.inferno.sparked-fhir.com' > /dev/null
+          echo "::endgroup::"

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -34,20 +34,15 @@ jobs:
           ruby-version: '3.3.6'
           bundler-cache: true
 
-      - name: RSpec
+      - name: Dev dependency set resolves (Gemfile.dev, frozen)
         env:
-          APP_ENV: test   # config/database.yml test = sqlite :memory: — no DB service needed
-        run: bundle exec rake spec
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
+        run: bundle install
 
       - name: Static site generates (Jekyll)
         run: |
           cp .env.development .env
           bundle exec rake web:generate_dev
-
-      - name: Dev dependency set resolves (Gemfile.dev, frozen)
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.dev
-        run: bundle install
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -72,3 +67,10 @@ jobs:
             --set nginx.platformImageUri=ghcr.io/hl7au/au-fhir-inferno:ci-nginx-pr \
             --set 'ingress.hostnames[0]=pr-0.preview.inferno.sparked-fhir.com' > /dev/null
           echo "::endgroup::"
+
+      # Boots the full Inferno app (spec_helper → migrations on sqlite :memory:), so it's
+      # the heaviest check — run last so the deterministic checks above always report.
+      - name: RSpec
+        env:
+          APP_ENV: test
+        run: bundle exec rake spec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,10 @@
 
 eval_gemfile 'Gemfile.common'
 
-# Released AU Core test kit (published on RubyGems by hl7au).
-# NOTE: the newest published version is 1.4.0; code on the kit's master is ahead
-# (1.4.2, unreleased). Once 1.4.2 is tagged + released, bump this to '~> 1.4'.
+# Released AU Core test kit (published on RubyGems by hl7au). '~> 1.4.0' means
+# >= 1.4.0, < 1.5.0; Gemfile.lock pins the exact version (currently 1.4.2). Bump the
+# lock (bundle update au_core_test_kit) to adopt new 1.4.x releases; widen to '~> 1.4'
+# only if you want 1.5+ automatically.
 gem 'au_core_test_kit', '~> 1.4.0'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit on master

--- a/docs/cicd-overhaul-plan.md
+++ b/docs/cicd-overhaul-plan.md
@@ -16,6 +16,22 @@ Work is tracked on the [Inferno Testing Framework board](https://github.com/orgs
 
 ---
 
+## Current state (2026-06-23)
+
+- **Phase 1 — pragmatic fixes: shipped to prod.** `Gemfile.dev` split, automated
+  prod-promotion (push a `promote/prod-<sha>` branch + a human merges it — no admin
+  needed), reproducibility cleanup, CODEOWNERS + PR template, board auto-add workflow.
+  `development → master` was merged (#79); prod runs released `au_core` 1.4.2 + AU PS.
+- **Phase 2 — preview environments: complete and validated end-to-end.** Labelling a PR
+  `preview` spins up an ephemeral per-PR deploy at
+  `pr-<n>.preview.inferno.sparked-fhir.com`; closing/merging/unlabelling tears it down.
+  See the dedicated section below and `docs/preview-environments.md`.
+- **Phase 3 — trunk cutover: not started.** Next major phase.
+- **Blocked on Brett (admin/org actions):** branch protection on `master`,
+  `ADD_TO_PROJECT_PAT` org secret, and a set of new repo/board-admin asks (Track B).
+
+---
+
 ## How it works today
 
 ### Deploy flow (branch → environment)
@@ -59,6 +75,8 @@ can: push branches, merge PRs, create releases, and add/modify any files or work
 We **cannot**: set branch protection/rulesets, change repo Actions settings, or create
 repo/org secrets. Those few admin/org actions are batched into **Track B** below for the
 repo/org owner (Brett). Everything else proceeds through normal PR / merge / Actions.
+**Update (2026-06-23):** requested full repo admin (au-fhir-inferno + au-ps-inferno) + board
+admin + generator push from Brett — see Track B.
 
 ---
 
@@ -75,9 +93,10 @@ repo/org owner (Brett). Everything else proceeds through normal PR / merge / Act
 
 ---
 
-## Phase 1 — Pragmatic fixes
+## Phase 1 — Pragmatic fixes *(shipped to prod)*
 
 > Removes the daily friction and makes prod safe, without changing the branch model.
+> Shipped via the `development → master` merge (#79); prod runs released `au_core` 1.4.2.
 
 ### 1.1 — Gemfile split *(done — see PR)*
 Base `Gemfile` (prod/released) + `Gemfile.common` (shared) + `Gemfile.dev` (bleeding-edge
@@ -118,20 +137,48 @@ field. One-time backfill of existing open items.
 
 ---
 
-## Phase 2 — Preview environments
+## Phase 2 — Preview environments *(complete — validated end-to-end 2026-06-22)*
 
-Per-PR ephemeral deploys so any branch can get a live URL.
+Per-PR ephemeral deploys. **Add the `preview` label to a PR** → a live environment at
+`https://pr-<n>.preview.inferno.sparked-fhir.com`; close / merge / unlabel tears it down.
+Full user-facing guide: `docs/preview-environments.md`.
 
-- ArgoCD **ApplicationSet** (PR generator) on `au-fhir-inferno` → namespace `inferno-pr-<n>`,
-  hostname `pr-<n>.dev.inferno.sparked-fhir.com`, auto-deleted on PR close.
-- **Wildcard TLS + DNS** (`*.dev.inferno.sparked-fhir.com`) so new hostnames need no
-  per-branch gateway edits (static per-FQDN listeners are the current blocker).
-- Loosen the `proj-inferno` AppProject to an `inferno-*` namespace pattern (or a dedicated
-  ephemeral project); keep prod tight.
-- Chart hygiene (prereq): unify namespacing (`.Release.Namespace` vs `.Values.namespace`),
-  drop the duplicated inline overrides in `inferno-dev.yaml`.
-- Per-PR data/secrets: ephemeral Postgres-in-namespace vs schema-per-PR; reusable IAM/secret
-  strategy.
+**How it works**
+
+```
+add `preview` label
+   ├─► build-and-release-package.yaml builds the PR HEAD (Gemfile.dev) and pushes
+   │     ghcr.io/hl7au/au-fhir-inferno:<head-sha>-pr  (+ -nginx-pr)
+   ├─► preview-comment.yaml posts a sticky PR comment with the URL, polls, flips to "live"
+   └─► ArgoCD ApplicationSet `inferno-previews` (sparked-argo) — GitHub PR generator
+         filtered by the `preview` label → Application `inferno-pr-<n>` deploying the
+         chart from the PR HEAD into namespace `inferno-pr-<n>`, with the <head-sha>-pr
+         image and an ephemeral in-namespace Postgres.
+```
+
+**What shipped**
+
+- **PR-generator ApplicationSet** `apps/inferno-previews.yaml` (sparked-argo #37). Anonymous
+  GitHub polling (repo is public), 30-min requeue.
+- **Per-PR image build** — `build-and-release-package.yaml` builds `preview`-labelled PRs by
+  HEAD SHA, dev-flavoured (au-fhir-inferno #84).
+- **Wildcard TLS + DNS** `*.preview.inferno.sparked-fhir.com` + gateway listener (`from: All`)
+  (sparked-argo #35).
+- **AppProject** allows `inferno-pr-*` namespaces (sparked-argo #36).
+- **Ephemeral in-namespace Postgres** via the chart's `postgresql.enabled` toggle. Two chart
+  bugs found + fixed by the first live run: double-quoted in-namespace `POSTGRES_HOST` (#84),
+  and the dead `docker.io/bitnami/postgresql` tag → `bitnamilegacy` (#85). See
+  [`preview-postgres-bitnamilegacy`].
+- **Teardown** — `createNamespace` value + `templates/namespace.yaml` make ArgoCD *manage*
+  the namespace so the finalizer prunes it (was lingering empty); au-fhir-inferno #87 +
+  sparked-argo #38.
+- **PR comment** — `preview-comment.yaml` sticky live-link comment (au-fhir-inferno #86).
+
+**Access control** — only Triage+/Write collaborators can apply labels, and fork PRs can't
+push images, so the `preview` label *is* the gate. No extra guard needed.
+
+**Optional follow-ups** — a GitHub webhook to replace the 30-min poll (creation/teardown
+within seconds); preview namespaces are intentionally un-hardened (no NetworkPolicies).
 
 ---
 
@@ -149,23 +196,34 @@ Per-PR ephemeral deploys so any branch can get a live URL.
 ## Track B — needs the repo/org owner (Brett)
 
 Batched admin/org actions we can't perform with `maintain`. Each has a no-admin interim
-so work continues meanwhile.
+so work continues meanwhile. **Email sent to Brett 2026-06-23** requesting the access below.
 
 | Item | Why it needs admin | Interim |
 | --- | --- | --- |
-| **Branch protection / ruleset on `master`** (require PR + 1 review + passing `quality-control`) | Repo-admin only | Prod gate is "a human merges the promotion PR" — works, just not enforced. CODEOWNERS already auto-requests reviewers. |
-| **Org secret `ADD_TO_PROJECT_PAT`** + approve a fine-grained org PAT (Projects R/W + repo Issues/PRs read) | Org/repo-admin only | `add-to-project` workflow is merged but a graceful no-op until the secret exists; board populated manually via `gh` (has `project` scope). |
+| **Repo admin on `hl7au/au-fhir-inferno` + `hl7au/au-ps-inferno`** | To implement PR gates (branch protection / rulesets, required checks) + wire up integration and unit tests. Subsumes the branch-protection and Actions-settings asks below. | Work proceeds on `maintain`; gates are conventions (human-merge) not enforcement. |
+| **Branch protection / ruleset on `master`** (require PR + 1 review + passing `quality-control`) | Repo-admin only (covered by the repo-admin ask above) | Prod gate is "a human merges the promotion PR" — works, just not enforced. CODEOWNERS auto-requests reviewers. |
+| **Admin on the project board** ([Inferno Testing Framework](https://github.com/orgs/hl7au/projects/2)) | To manage fields/automation/views for tracking | Board used as-is; items added manually via `gh` (`project` scope). |
+| **Org secret `ADD_TO_PROJECT_PAT`** + approve a fine-grained org PAT (Projects R/W + repo Issues/PRs read) | Org/repo-admin only | `add-to-project` workflow is merged but a graceful no-op until the secret exists. |
+| **Push/maintain on `hl7au/inferno_suite_generator`** *(least important)* | To shorten the generated-filename scheme + regenerate (see below) | Parked; AU PS stays git-ref-pinned, not RubyGems-released. |
 
 Explicitly **not** needed: the "Allow GitHub Actions to create and approve pull requests"
 setting — the prod-promotion workflow was reworked to push a branch + surface a one-click
 PR link, so it needs only `contents: write`.
 
+### AU PS RubyGems release — blocked on the generator (inferno_suite_generator#22)
+
+`au_ps_inferno` cannot be published to RubyGems: the generator emits filenames that exceed
+the **100-char gem/tar limit**, so `gem build` fails. The generator
+(`hl7au/inferno_suite_generator`) needs its filename scheme shortened and the AU PS kit
+regenerated. Until then AU PS stays **git-ref-pinned** in `Gemfile`/`Gemfile.dev`. Pavel will
+hit the same limit. Tracked at `hl7au/inferno_suite_generator#22`.
+
 ## Open items needing a decision
 
-- **Dev validator image** `markiantorno/validator-wrapper:latest` (prod pins `1.0.68`): is
-  dev intentionally tracking latest (like the tx server), or should it be pinned?
-- **`prod` branch trigger** in `build-and-release-package.yaml`: the `prod` branch is stale
-  (last used 2025-10-30). Remove the trigger, or is it still part of a flow?
+- ~~**Dev validator image** `markiantorno/validator-wrapper:latest`~~ — **decided:** dev
+  intentionally tracks latest for speed (like the tx server); prod stays pinned. Do not pin dev.
+- ~~**`prod` branch trigger**~~ — **resolved:** `build-and-release-package.yaml` was rewritten
+  (master/development pushes + master PRs + `preview`-labelled PRs); no `prod` branch trigger remains.
 - **Terraform consolidation**: merge the two near-duplicate Terraform workflows and add a
   prod-`apply` gate via `workflow_dispatch` (no-admin) rather than GitHub Environments.
 - **Org-level `RUBYGEMSKEY`**: unverified (gh 403). Each kit repo already has its own

--- a/docs/phase3-trunk-cutover.md
+++ b/docs/phase3-trunk-cutover.md
@@ -1,0 +1,135 @@
+# Phase 3 — Trunk cutover runbook
+
+Status: **draft / not yet executed** · Owner: Kyle Pettigrew · Drafted: 2026-06-23
+
+The design + step-by-step checklist for collapsing the two long-lived branches into a
+single trunk. This document is reviewed and merged first; **execution happens in a
+separate, deliberate session** (low prod traffic) using the checklist below.
+
+> **Scope correction vs the original roadmap.** The roadmap said "collapse
+> development + master → `main`". On review, the rename is **cosmetic** — trunk-based
+> development is about having *one* long-lived branch, not its name. Renaming would force
+> a default-branch switch (**admin-only**) and re-point every clone for no functional
+> gain. So **the trunk stays `master`**, and Phase 3 carries **no hard admin dependency**
+> — branch protection is a fast-follow, not a gate (see below).
+
+---
+
+## Goal / end state
+
+One trunk. Feature work flows: **branch → PR → `master` → auto-deploy to staging →
+promotion PR → prod.**
+
+- `master` = trunk. `development` retired.
+- Every push to `master`: build **one** image `:<sha>`, auto-deploy it to staging, and
+  open a prod-promotion PR for the *same* image (build once, deploy many).
+- **Staging** = the env currently at `development.inferno.sparked-fhir.com`
+  (conceptually re-labelled; hostname unchanged), now a **prod mirror** (released-flavour).
+- **Prod** = promotion PR (human gate), shipping the identical `:<sha>` artifact staging
+  already ran.
+- **Bleeding-edge / unreleased kit commits** live in **preview environments**
+  (Gemfile.dev), not in a persistent branch. Previews are unchanged.
+
+---
+
+## Why no admin is required (and the protection nuance)
+
+- No rename → no default-branch change → **no admin action to cut over.**
+- We can do every cutover step with `maintain` on au-fhir-inferno + our admin on
+  `aehrc/sparked-argo`.
+- **Branch protection is not a blocker.** `master` has none today, so going trunk is *not
+  less* protected — same (zero) enforcement. It's a fast-follow ask to Brett, not a gate.
+- Honest nuance: protection is *more valuable* under trunk, because today the
+  `development → master` merge is an implicit human checkpoint that disappears. Mitigations
+  that hold without protection: **prod keeps its human gate** (you merge the promotion PR),
+  and **`quality-control` already runs on pushes to `master`** (advisory signal). So add
+  protection soon — but it doesn't block the cutover.
+
+---
+
+## Decisions to confirm (defaults baked; adjust in review)
+
+1. **Trunk = `master`, no rename.** *(recommended)*
+2. **Build once, prod-flavour trunk — THE consequential decision.** `master` builds a
+   single released-flavour image (`Gemfile` + `web:generate_prod`); **staging and prod run
+   the same artifact.** Bleeding-edge (Gemfile.dev / unreleased kit SHAs) moves to preview
+   envs. *Alternative:* keep building two flavours (staging = bleeding-edge, prod =
+   released) — but then staging ≠ the artifact you promote, which throws away a core trunk
+   benefit. **Recommended: build once.** This also makes `Gemfile.dev`'s only job "preview
+   override", matching the earlier decision.
+3. **Staging deploys automatically via the existing image write-back** (repointed to
+   `master` + `values-dev.yaml`, `[skip ci]`; `infra/**` is paths-ignored so no rebuild
+   loop). *(recommended)*
+   > Corrects an earlier suggestion of "promotion-PR for staging": a promotion PR isn't
+   > *auto*, and the roadmap wants staging to auto-track the trunk. Retiring the write-back
+   > entirely (ArgoCD Image Updater) is a clean **future** improvement, not part of the cutover.
+4. **Prod = promotion PR** (unchanged human release gate).
+5. **`Gemfile.dev` = preview-override only.** Trunk `Gemfile` stays released-form (`au_ps`
+   remains git-SHA-pinned until it can publish to RubyGems). The "trunk Gemfile is
+   git-ref-free" guard is **deferred** until AU PS releases.
+6. **Keep filenames / ArgoCD app names** (`values-dev.yaml`, `inferno-dev` Application) to
+   minimise churn; re-label to "staging" conceptually. Optional rename later.
+7. **Branch protection on `master`** (require PR + 1 review + passing `quality-control`) =
+   fast-follow ask to Brett.
+
+---
+
+## Cutover steps
+
+Legend: **[us]** = doable with current access · **[Brett]** = admin, fast-follow.
+
+1. **[us] Bring `master` current.** Final `development → master` merge **commit** (never
+   squash — preserves ancestry). Confirm `quality-control` is green on `master`.
+2. **[us] Swap in the trunk build workflow.** Replace
+   `.github/workflows/build-and-release-package.yaml` with the trunk version (drafted at
+   `docs/phase3/build-and-release-package.yaml`): drops the `development` trigger and the
+   dev-flavour trunk build; `master` builds `:<sha>` once, writes the staging tag back to
+   `values-dev.yaml`, and opens the prod-promotion PR. Preview path unchanged.
+3. **[us · sparked-argo] Repoint staging.** `inferno-dev` Application
+   `targetRevision: development → master`. (Prod already tracks `master`.)
+4. **[us] Smoke test.** Push a trivial commit to `master` → `:<sha>` builds → staging
+   (`development.inferno…`) auto-updates and is healthy → a prod-promotion PR appears (don't
+   merge unless actually releasing).
+5. **[us] Retire `development`.** Announce; stop deploying from it; **after** staging-from-
+   master is proven, delete the branch (keep an archived tag/ref for safety).
+6. **[Brett] Branch protection** ruleset on `master`: require PR + 1 review + passing
+   `quality-control`. *(fast-follow)*
+7. **[us] Tidy up.** Update docs / CODEOWNERS / PR template to trunk language; mark Phase 3
+   complete in `docs/cicd-overhaul-plan.md` + memory.
+
+---
+
+## Verification checklist
+
+- [ ] Staging serves the released-flavour build of the latest `master` commit.
+- [ ] Prod is untouched until a promotion PR is merged (and ships the same `:<sha>`).
+- [ ] Preview envs still spin up on a `preview`-labelled PR.
+- [ ] `quality-control` runs on pushes to `master`.
+- [ ] No rebuild loop from the staging write-back (`[skip ci]` + `infra/**` paths-ignore).
+
+---
+
+## Rollback
+
+Low-risk — `master` is never renamed or destroyed, and **prod stays human-gated
+throughout** (the promotion PR is the only path to prod), so prod cannot auto-break.
+
+1. Revert the workflow commit (restores the development/master split behaviour).
+2. Repoint the `inferno-dev` Application `targetRevision` back to `development`.
+3. `development` still exists (don't delete until proven) → resume as before.
+
+---
+
+## Handover — kickoff prompt for the execution session
+
+```
+Execute Phase 3 (trunk cutover) for AU Inferno. Read docs/phase3-trunk-cutover.md and
+memory `inferno-cicd-overhaul-roadmap` first. Trunk = master (no rename). Follow the
+"Cutover steps" checklist; the trunk build workflow is pre-drafted at
+docs/phase3/build-and-release-package.yaml. Confirm the "Decisions to confirm" defaults
+with me before step 2. Prod stays human-gated via the promotion PR — do not merge a
+promotion PR without my go. Do the development→master merge, swap the workflow, repoint
+the inferno-dev ArgoCD app (sparked-argo) to master, smoke-test staging, then retire
+development. Branch protection is Brett's fast-follow, not a blocker. Open PRs; verify
+each with helm template + watching ArgoCD sync.
+```

--- a/docs/phase3/build-and-release-package.yaml
+++ b/docs/phase3/build-and-release-package.yaml
@@ -1,0 +1,156 @@
+# ⚠️ PROPOSED — Phase 3 trunk version of build-and-release-package.yaml. NOT ACTIVE.
+# Lives under docs/phase3/ so it can be reviewed ahead of the cutover without running.
+# At cutover (step 2 of docs/phase3-trunk-cutover.md) this replaces
+# .github/workflows/build-and-release-package.yaml. Reflects the recommended decisions:
+# trunk = master, build once (released flavour) for staging + prod, staging auto-deploys
+# via write-back, prod via promotion PR, previews unchanged.
+name: Build and Release Inferno and Nginx Images
+
+on:
+  push:
+    branches:
+      - master            # the trunk
+    paths-ignore:         # config-only pushes (image-tag write-backs, docs) must not rebuild
+      - 'infra/**'
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    # Preview images for `preview`-labelled PRs (any base). PR quality gating lives in
+    # quality-control.yaml; this workflow's only PR job is building preview images.
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    # Build on: any push to the trunk; OR a PR carrying the `preview` label.
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set environment from event
+        id: config
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && \
+             [ "${{ contains(github.event.pull_request.labels.*.name, 'preview') }}" = "true" ]; then
+            # Preview: dev-flavoured (Gemfile.dev), tagged by PR head SHA.
+            echo "environment=pr" >> $GITHUB_OUTPUT
+            echo "rake_task=web:generate_dev" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile.dev" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "app_tag=${{ github.event.pull_request.head.sha }}-pr" >> $GITHUB_OUTPUT
+            echo "nginx_tag=${{ github.event.pull_request.head.sha }}-nginx-pr" >> $GITHUB_OUTPUT
+            echo "use_dev_env=true" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile.dev" >> $GITHUB_ENV
+          else
+            # Trunk (push to master): build ONCE, released flavour. Staging + prod run this
+            # same artifact (no -dev/-prod split — build once, deploy many).
+            echo "environment=trunk" >> $GITHUB_OUTPUT
+            echo "rake_task=web:generate_prod" >> $GITHUB_OUTPUT
+            echo "bundle_gemfile=Gemfile" >> $GITHUB_OUTPUT
+            echo "image_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "app_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "nginx_tag=${{ github.sha }}-nginx" >> $GITHUB_OUTPUT
+            echo "use_dev_env=false" >> $GITHUB_OUTPUT
+            echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/Gemfile" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Use dev environment file
+        if: steps.config.outputs.use_dev_env == 'true'
+        run: cp .env.development .env
+
+      - name: Generate static content
+        run: bundle exec rake ${{ steps.config.outputs.rake_task }}
+
+      - name: Log in to Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push app image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          build-args: |
+            BUNDLE_GEMFILE=${{ steps.config.outputs.bundle_gemfile }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}
+
+      - name: Build and push Nginx image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./nginx.Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}
+
+      # --- Trunk only (push to master): auto-deploy to staging + open prod promotion PR ---
+
+      # Staging auto-deploys: write the new tags into values-dev.yaml and commit back.
+      # [skip ci] + the infra/** paths-ignore above prevent a rebuild loop. ArgoCD
+      # (inferno-dev, targetRevision: master) syncs staging to the new image.
+      - name: Update staging image tags (values-dev.yaml)
+        if: github.event_name == 'push'
+        run: |
+          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}|" infra/helm/inferno/values-dev.yaml
+          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}|" infra/helm/inferno/values-dev.yaml
+
+      - name: Commit staging tags
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add infra/helm/inferno/values-dev.yaml
+          git commit -m "chore: deploy ${{ github.sha }} to staging [skip ci]"
+          git push origin master
+
+      # Prod promotion: push the SAME artifact's tags to a branch and surface a one-click
+      # PR link. Merging that PR = the prod release (human gate). ArgoCD (inferno-prod,
+      # targetRevision: master) syncs prod on merge.
+      - name: Push prod promotion branch
+        if: github.event_name == 'push'
+        run: |
+          BRANCH="promote/prod-${{ github.sha }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}|" infra/helm/inferno/values-prod.yaml
+          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}|" infra/helm/inferno/values-prod.yaml
+          git add infra/helm/inferno/values-prod.yaml
+          git commit -m "chore: promote prod to ${{ github.sha }}"
+          git push --force-with-lease origin "$BRANCH"
+          {
+            echo "## 🚀 Prod promotion ready"
+            echo ""
+            echo "Staging is already running this build. Merge to release it to prod:"
+            echo ""
+            echo "**https://github.com/${{ github.repository }}/compare/master...$BRANCH?expand=1**"
+            echo ""
+            echo "- app:   \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}\`"
+            echo "- nginx: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -1,0 +1,77 @@
+# Preview environments
+
+Every pull request can get its own short-lived, fully-deployed copy of Inferno —
+useful for reviewing UI/content changes, exercising a test-kit gem bump, or sharing
+a running build with reviewers before it merges.
+
+## How to spin one up
+
+1. Open a PR (against `development` or `master`).
+2. Add the **`preview`** label.
+
+That's it. Within a few minutes a bot comment appears on the PR with the URL:
+
+```
+https://pr-<PR-number>.preview.inferno.sparked-fhir.com
+```
+
+The comment updates to ✅ **live** once the environment is serving.
+
+> **Who can do this:** only collaborators with **Triage / Write** (or above) can apply
+> labels, so only they can create preview environments. PRs from forks cannot create
+> previews (they can't apply labels and can't push images).
+
+## What happens behind the scenes
+
+```
+add `preview` label
+   │
+   ├─►  GitHub Actions (build-and-release-package.yaml)
+   │       builds this PR's HEAD commit (dev-flavoured: Gemfile.dev) and pushes
+   │       ghcr.io/hl7au/au-fhir-inferno:<head-sha>-pr  (+ -nginx-pr)
+   │
+   └─►  ArgoCD ApplicationSet `inferno-previews` (in aehrc/sparked-argo)
+           PR generator (filtered by the `preview` label) creates an Application
+           `inferno-pr-<n>` that deploys the chart from the PR's HEAD commit into
+           namespace `inferno-pr-<n>`, using the <head-sha>-pr image and an
+           ephemeral in-namespace Postgres (no RDS).
+```
+
+- **Hostname:** `pr-<n>.preview.inferno.sparked-fhir.com`, covered by the
+  `*.preview.inferno.sparked-fhir.com` wildcard TLS cert + gateway listener.
+- **Database:** an ephemeral in-namespace Postgres (Bitnami subchart), created and
+  destroyed with the environment. No connection to dev/prod RDS.
+- **Updates:** push more commits to the PR and the preview rebuilds and redeploys
+  automatically (the image is re-tagged for the new HEAD commit).
+
+## Previewing a test-kit (gem) change
+
+Previews build with `Gemfile.dev`, which pins `au_core_test_kit` and `au_ps_inferno`
+by git ref. To preview a change to one of those kits:
+
+1. Push your change to the kit repo (e.g. `hl7au/au-ps-inferno`) and note the commit SHA.
+2. In an `au-fhir-inferno` branch, bump that gem's `ref:` in `Gemfile.dev` and
+   regenerate `Gemfile.dev.lock` (Ruby 3.3.6, clean `GEM_HOME`).
+3. Open the PR, add the `preview` label — the preview runs your kit change.
+
+## Teardown
+
+The environment is **ephemeral**. It is removed automatically when you either:
+
+- **close** the PR, or
+- **merge** the PR (merging closes it), or
+- **remove** the `preview` label.
+
+ArgoCD deletes the `inferno-pr-<n>` Application and prunes the entire namespace —
+app, validator, redis, and the ephemeral Postgres (including its volume). Nothing
+lingers. Because merging also tears it down, a preview is a *pre-merge* review tool.
+
+## Notes & limitations
+
+- **Timing:** the ApplicationSet polls GitHub roughly every 30 minutes, so creation
+  and teardown can take up to that long to begin (a webhook to make this instant is a
+  possible future improvement). First start also includes a validator warmup (~5–10 min).
+- **Not hardened:** preview namespaces have no NetworkPolicies (unlike dev/prod) — fine
+  for ephemeral review environments, but don't treat a preview as a secure deployment.
+- **Persistent dev** (`development.inferno.sparked-fhir.com`) is unaffected — previews
+  are additive.

--- a/docs/preview-smoke-test.md
+++ b/docs/preview-smoke-test.md
@@ -1,0 +1,4 @@
+# Preview environment smoke test
+
+Throwaway marker to exercise the Phase 2 per-PR preview loop end-to-end
+(build → ApplicationSet → deploy → teardown). Safe to delete with its PR.

--- a/docs/preview-smoke-test.md
+++ b/docs/preview-smoke-test.md
@@ -1,4 +1,0 @@
-# Preview environment smoke test
-
-Throwaway marker to exercise the Phase 2 per-PR preview loop end-to-end
-(build → ApplicationSet → deploy → teardown). Safe to delete with its PR.

--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: inferno
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   FHIR_RESOURCE_VALIDATOR_URL: {{ default "http://validator-api:3500" .Values.inferno.externalValidatorUrl | quote }}
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}

--- a/infra/helm/inferno/templates/configs/inferno-httproute.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-httproute.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: inferno-route
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
     - name: main-gateway

--- a/infra/helm/inferno/templates/configs/inferno-redirect-httproute.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-redirect-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: inferno-redirect-route
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
     - name: main-gateway

--- a/infra/helm/inferno/templates/configs/postgresql-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/postgresql-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql-configmap
   namespace: {{ .Release.Namespace }}
 data:
-  POSTGRES_HOST: {{ default (printf "%s-postgresql" .Release.Name | quote) (index .Values.postgresql "externaldbhost") | quote }}
+  POSTGRES_HOST: {{ default (printf "%s-postgresql" .Release.Name) (index .Values.postgresql "externaldbhost") | quote }}
   {{- if .Values.externalSecrets.enabled }}
   POSTGRES_USER: {{ .Values.externalSecrets.username | default "postgres" | quote }}  # Hardcode or pass as value since it's not sensitive
   {{- else }}

--- a/infra/helm/inferno/templates/configs/redirect-nginx-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/redirect-nginx-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redirect-nginx-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   default.conf: |
     server {

--- a/infra/helm/inferno/templates/configs/validator-presets-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/validator-presets-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: validator-presets
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   presets.json: |
     [

--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-worker
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:

--- a/infra/helm/inferno/templates/deployments/inferno.hpa.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: inferno-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/infra/helm/inferno/templates/deployments/nginx.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/nginx.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-app
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.inferno.replicas | default 2 }}
   selector:

--- a/infra/helm/inferno/templates/deployments/redirect.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redirect.deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redirect-nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redirect-nginx
 spec:

--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inferno-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1 # need clustering for multiple replicas
   strategy:

--- a/infra/helm/inferno/templates/namespace.yaml
+++ b/infra/helm/inferno/templates/namespace.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.createNamespace }}
+# Preview environments only. When ArgoCD renders the Namespace as a managed resource,
+# the Application's resources-finalizer prunes it on deletion (PR closed / `preview`
+# label removed) — so teardown removes the namespace itself, not just its contents.
+# ArgoCD's CreateNamespace=true sync option creates a namespace it does NOT track, so
+# without this the empty namespace would linger after teardown.
+#
+# dev/prod leave this false and target their pre-existing namespaces — templating a
+# Namespace there would make ArgoCD try to adopt and (on app deletion) delete them.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+{{- end }}

--- a/infra/helm/inferno/templates/redis.pvc.yaml
+++ b/infra/helm/inferno/templates/redis.pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redis-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/infra/helm/inferno/templates/services/inferno.service.yaml
+++ b/infra/helm/inferno/templates/services/inferno.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inferno
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/infra/helm/inferno/templates/services/nginx.service.yaml
+++ b/infra/helm/inferno/templates/services/nginx.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/infra/helm/inferno/templates/services/redirect.service.yaml
+++ b/infra/helm/inferno/templates/services/redirect.service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redirect-nginx
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redirect-nginx
 spec:

--- a/infra/helm/inferno/templates/services/redis.service.yaml
+++ b/infra/helm/inferno/templates/services/redis.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inferno-redis
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   ports:

--- a/infra/helm/inferno/templates/services/validator-api.service.yaml
+++ b/infra/helm/inferno/templates/services/validator-api.service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   sessionAffinity: ClientIP

--- a/infra/helm/inferno/templates/statefulsets/validator-api.hpa.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: validator-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: validator-api  # Required for StatefulSet
   replicas: {{ .Values.validator.replicas | default 2 }}

--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -3,7 +3,7 @@ ingress:
     - development.inferno.sparked-fhir.com
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:47849995ac7a76d7c0e4318b77a9cf08a88026f9-dev
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:8a8c4ea84d9903f732447693bf7738bdec5428af-dev
   usesWrapper: true
   validatorImageUri: markiantorno/validator-wrapper:latest
   replicas: 1
@@ -27,7 +27,7 @@ validatorAutoscaling:
   targetCPUUtilizationPercentage: 60
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:47849995ac7a76d7c0e4318b77a9cf08a88026f9-nginx-dev
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:8a8c4ea84d9903f732447693bf7738bdec5428af-nginx-dev
 
 
 externalSecrets:

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -44,6 +44,14 @@ validatorAutoscaling:
 postgresql:
   enabled: false # enable if not using rds from aws-impl
   externaldbhost: null # This can be overridden during chart deployment
+  # Bitnami purged versioned tags from docker.io/bitnami (mid-2025) and moved them
+  # to the bitnamilegacy archive, so the subchart's pinned default tag 404s. Point
+  # the in-namespace Postgres (preview envs only — dev/prod use RDS) at the archive.
+  # Stopgap: bitnamilegacy receives no updates and will eventually be removed; revisit
+  # by bumping/replacing the postgresql subchart.
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
   containerPorts:
     postgresql: 5432
   global:

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -1,3 +1,8 @@
+# Render the destination Namespace as a managed resource so ArgoCD prunes it on
+# teardown. Preview environments set this true; dev/prod leave it false and use their
+# pre-existing namespaces. See templates/namespace.yaml.
+createNamespace: false
+
 ingress:
   hostnames:
     - example.inferno.sparked-fhir.com


### PR DESCRIPTION
Final development → master merge to bring the trunk current ahead of the Phase 3 cutover.

Carries across the work merged to development since the last promotion:
- Per-PR preview environments (chart namespace hygiene, per-PR image builds, teardown, PR-comment link).
- `quality-control` PR gate (`.github/workflows/quality-control.yaml` + `.rspec`).
- Preview-environment docs and the CI/CD overhaul plan update.
- Phase 3 trunk-cutover runbook (`docs/phase3-trunk-cutover.md`) + the proposed trunk build workflow staged under `docs/phase3/`.

Merge commit (not squash) to preserve development↔master ancestry. No image rebuild loop: this merge advances master; the build workflow on master is swapped to the trunk version as the next step.