### PR TITLE
docs(dockerfile): describe Gemfile.dev as the preview override (trunk)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN mkdir -p $INSTALL_PATH
 
 WORKDIR $INSTALL_PATH
 
-# Select the dependency set: the default Gemfile (prod / released test kits) or
-# Gemfile.dev (bleeding-edge, unreleased test-kit commits) for the dev environment.
-# Each Gemfile has its own committed lockfile (Gemfile.lock / Gemfile.dev.lock).
+# Select the dependency set: the default Gemfile (released test kits — what master
+# builds once for staging + prod) or Gemfile.dev (bleeding-edge, unreleased test-kit
+# commits) for preview environments. Each Gemfile has its own committed lockfile
+# (Gemfile.lock / Gemfile.dev.lock).
 ARG BUNDLE_GEMFILE=Gemfile
 ENV BUNDLE_GEMFILE=$INSTALL_PATH$BUNDLE_GEMFILE
 


### PR DESCRIPTION
Trunk-accurate the Dockerfile build-arg comment: the default `Gemfile` is the released set `master` builds once for staging + prod; `Gemfile.dev` is the bleeding-edge override used by **preview** environments, not a persistent dev branch.

Comment-only change (functionally identical image). Doubles as the Phase 3 step-4 smoke commit: merging this is the first push to `master` under the new trunk workflow, exercising build-once → staging write-back → prod-promotion PR.