### PR TITLE
fix(validator): disable session-cache time-expiry to keep warm sessions

### DIFF
--- a/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
+++ b/infra/helm/inferno/templates/statefulsets/validator-api.statefulset.yaml
@@ -34,6 +34,15 @@ spec:
           value: "-Xmx8g"
         - name: VALIDATION_SERVICE_PRESETS_FILE_PATH
           value: "/presets/presets.json"
+        # Keep warm validator sessions alive across idle gaps instead of letting the
+        # wrapper's 60-min expire-after-access default silently evict them (which forces
+        # a ~50s cold engine rebuild on the first validation of a later run). See the
+        # validator.sessionCache* notes in values.yaml. size is memory-bound — each
+        # cached engine is large and these pods run close to the 12Gi limit.
+        - name: SESSION_CACHE_DURATION
+          value: {{ .Values.validator.sessionCacheDuration | default -1 | quote }}
+        - name: SESSION_CACHE_SIZE
+          value: {{ .Values.validator.sessionCacheSize | default 6 | quote }}
         ports:
         - containerPort: 3500
         volumeMounts:

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -26,6 +26,23 @@ inferno:
 
 validator:
   storageClassName: "gp3-encrypted"  # Use default EBS storage class for validator caches
+  # Validator session cache (env: SESSION_CACHE_DURATION / SESSION_CACHE_SIZE on the
+  # validator-wrapper). A "session" is a fully-built ValidationEngine keyed by a random
+  # UUID; Inferno reuses the UUID it gets back so all bundles/users in a run share one
+  # engine. The wrapper default is 60-min expire-after-access, which silently evicts
+  # warm sessions during idle gaps — so the first validation of any run that lands more
+  # than an hour after warmup pays the full ~50s cold rebuild (confirmed in prod).
+  #
+  # duration < 0 disables time-based expiry (sessions kept until LRU-evicted). size is
+  # the max number of resident engines (LRU). Each engine is large (loads ~20+ IG/tx
+  # packages), so size is memory-bound: the pod sits ~9.4Gi/12Gi at idle, so raise size
+  # only with headroom and watch RSS. The shared validator boot-warms one session per
+  # registered suite — dev warms ~5 distinct contexts (AU PS preview, AU Core
+  # 1.0.0-ballot/1.0.0/2.0.0, smart-app-launch) — so size must clear that working set
+  # plus headroom, else LRU (now the only eviction path) re-introduces cold starts.
+  # Each resident engine is a full build (~80-150Mi); 8 covers the 5 contexts + spare.
+  sessionCacheDuration: -1
+  sessionCacheSize: 8
 
 # Validator autoscaling — disabled by default.
 #


### PR DESCRIPTION
## Problem

The validator-wrapper session cache defaults to a **60-minute `expire-after-access` TTL** with a **4-entry max** (`SessionCacheFactoryImpl`: `SESSION_DEFAULT_DURATION=60`, `SESSION_DEFAULT_SIZE=4`). No `SESSION_CACHE_*` env was set on the StatefulSet, so prod runs on those defaults.

Inferno boot-warms one validator session per suite at startup (`InvokeValidatorSession`), stores each session id in its `validator_sessions` table, and re-sends it on later validations. The 60-minute idle expiry silently evicts those warm sessions, so a run landing more than an hour after warmup re-sends an id the validator no longer holds → `No such cached session` → full **~50s `ValidationEngine` rebuild** on the first validation. Confirmed in prod: startup cached 4 sessions, all gone ~2.5h later when a test run hit a cold validator.

## Change

Add two env vars to the `validator-api` StatefulSet, exposed via `values.yaml`:

- `SESSION_CACHE_DURATION=-1` — negative disables `expireAfterAccess`, so warm sessions persist until LRU eviction instead of time-expiring. This is the primary fix.
- `SESSION_CACHE_SIZE=8` — the shared validator boot-warms ~5 distinct contexts (AU PS preview, AU Core 1.0.0-ballot/1.0.0/2.0.0, smart-app-launch); the old default of 4 (and an initial 6) left too little headroom now that LRU is the only eviction path. 8 clears the working set plus spare. Each resident engine is ~80–150Mi, so this adds ~0.5–0.8Gi worst case under the current `-Xmx8g` / 12Gi limit.

## Verification

- Env keys and `negative ⇒ never-expire` semantics are byte-identical in wrapper `1.0.68` (prod) and `1.0.78` (dev/`latest`).
- `helm template` renders `SESSION_CACHE_DURATION="-1"` / `SESSION_CACHE_SIZE="8"` for both `values-dev.yaml` and `values-prod.yaml`.

## Notes / follow-ups (not in this PR)

- **Memory**: validator pods already sit ~9.4Gi/12Gi at idle; watch RSS after rollout. Tune `validator.sessionCacheSize` down if memory is tight.
- A rollout restarts the pod, so the first post-deploy run re-warms via the boot job (expected, one-time).
- Separate correctness bug found during investigation: the AU PS suite validates against `au-ps-bundle|1.0.0-ballot` but loads the `1.0.0-preview` IG (package contains `|1.0.0-preview`). To be fixed in au-ps-inferno.
- Optional hardening (`baseEngine` in suite `cli_context`) would turn cache misses into fast clones; deferred.