### PR TITLE
ci: push staging write-back via HEAD:master (fix detached-HEAD push)

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -126,7 +126,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add infra/helm/inferno/values-dev.yaml
           git commit -m "chore: deploy ${{ github.sha }} to staging [skip ci]"
-          git push origin master
+          # checkout@v4 with an explicit `ref` leaves a detached HEAD (no local `master`
+          # branch), so push the commit to the branch explicitly via HEAD:master. Plain
+          # (no force) so a concurrent human merge to master fails the push rather than
+          # being clobbered — the next trunk build re-applies the tag.
+          git push origin HEAD:master
 
       # Prod promotion: push the SAME artifact's tags to a branch and surface a one-click
       # PR link. Merging that PR = the prod release (human gate). ArgoCD (inferno-prod,


### PR DESCRIPTION
First trunk build (smoke test, commit 37f7ef5) built and pushed the images fine but failed the staging write-back:

```
[detached HEAD 5c85ce5] chore: deploy ... to staging [skip ci]
error: src refspec master does not match any
```

`actions/checkout@v4` checks out an explicit `ref` (PR head SHA / pushed SHA), leaving a **detached HEAD** with no local `master` branch — so `git push origin master` can't resolve `master`. Fix: push the write-back commit explicitly with `git push origin HEAD:master`.

Plain (non-force) push, so a racing human merge to `master` fails this push rather than clobbering it; the next trunk build re-applies the tag. The prod-promotion step is unaffected — it creates a local branch via `git switch -c`.

After merge, a follow-up push re-runs the smoke test end-to-end (write-back → staging sync → promotion PR).