### PR TITLE
ci: make staging write-back resilient to concurrent master merges

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -110,27 +110,36 @@ jobs:
 
       # --- Trunk only (push to master): auto-deploy to staging + open prod promotion PR ---
 
-      # Staging auto-deploys: write the new tags into values-dev.yaml and commit back.
-      # [skip ci] + the infra/** paths-ignore above prevent a rebuild loop. ArgoCD
-      # (inferno-dev, targetRevision: master) syncs staging to the new image.
-      - name: Update staging image tags (values-dev.yaml)
-        if: github.event_name == 'push'
-        run: |
-          sed -i "s|imageUrl:.*|imageUrl: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}|" infra/helm/inferno/values-dev.yaml
-          sed -i "s|platformImageUri:.*|platformImageUri: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}|" infra/helm/inferno/values-dev.yaml
-
-      - name: Commit staging tags
+      # Auto-deploy to staging: write the released tags into values-dev.yaml and push the
+      # commit back to master. checkout@v4 leaves a detached HEAD (we check out an explicit
+      # ref), so push via HEAD:master. A concurrent merge to master makes the push
+      # non-fast-forward; re-sync to the new tip, re-apply the tag and retry rather than
+      # failing the build or force-pushing over someone else's commit. [skip ci] + the
+      # infra/** paths-ignore above prevent a rebuild loop. ArgoCD (inferno-dev,
+      # targetRevision: master) syncs staging to the new image.
+      - name: Deploy to staging (values-dev.yaml write-back)
         if: github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add infra/helm/inferno/values-dev.yaml
-          git commit -m "chore: deploy ${{ github.sha }} to staging [skip ci]"
-          # checkout@v4 with an explicit `ref` leaves a detached HEAD (no local `master`
-          # branch), so push the commit to the branch explicitly via HEAD:master. Plain
-          # (no force) so a concurrent human merge to master fails the push rather than
-          # being clobbered — the next trunk build re-applies the tag.
-          git push origin HEAD:master
+          APP="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}"
+          NGINX="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}"
+          pushed=false
+          for attempt in 1 2 3 4 5; do
+            git fetch --quiet origin master
+            git reset --hard FETCH_HEAD
+            sed -i "s|imageUrl:.*|imageUrl: ${APP}|" infra/helm/inferno/values-dev.yaml
+            sed -i "s|platformImageUri:.*|platformImageUri: ${NGINX}|" infra/helm/inferno/values-dev.yaml
+            if git diff --quiet -- infra/helm/inferno/values-dev.yaml; then
+              echo "values-dev.yaml already at ${APP}; nothing to push"; pushed=true; break
+            fi
+            git commit -am "chore: deploy ${{ github.sha }} to staging [skip ci]"
+            if git push origin HEAD:master; then pushed=true; break; fi
+            echo "push rejected (attempt ${attempt}); master moved — re-syncing and retrying"
+          done
+          if [ "$pushed" != "true" ]; then
+            echo "::error::staging write-back could not be pushed after 5 attempts"; exit 1
+          fi
 
       # Prod promotion: push the SAME artifact's tags to a branch and surface a one-click
       # PR link. Merging that PR = the prod release (human gate). ArgoCD (inferno-prod,


### PR DESCRIPTION
The smoke-test build hit a real trunk failure mode: a config-only PR (#95, `infra/**` only → no build) merged to `master` mid-build, so the staging write-back's plain `git push origin HEAD:master` was rejected non-fast-forward and the build went red, skipping the staging deploy.

Make the write-back resilient: re-sync to the latest `master` tip, re-apply the image tags, and retry (up to 5×) on a non-fast-forward. A concurrent merge no longer reddens the build or blocks the deploy, and we still **never force-push** over another commit. Push is skipped when `values-dev.yaml` is already at the target tag (idempotent re-runs).

The two staging steps are merged into one `Deploy to staging` step so the re-apply + push is atomic. The prod-promotion step is unchanged (its own unique branch, no race).