### PR TITLE
Promote prod → 0e151a2 (trunk tag realignment, no behaviour change)

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:c983b73547f1f3a47f344ee7210b6c6cde5bf7da-prod
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:0e151a206378d921fdebbe653db08a326f5a70ac
   usesWrapper: true
   validatorImageUri: markiantorno/validator-wrapper:1.0.68
 
@@ -22,7 +22,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:c983b73547f1f3a47f344ee7210b6c6cde5bf7da-nginx-prod
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:0e151a206378d921fdebbe653db08a326f5a70ac-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod from `c983b73-prod` → `0e151a2` (the current trunk tip; staging has been running this exact artifact).

## What changes in the cluster
Only the app + nginx **image tags** in `values-prod.yaml`:

| | from | to |
|---|---|---|
| app | `…:c983b73-prod` | `…:0e151a2` |
| nginx | `…:c983b73-nginx-prod` | `…:0e151a2-nginx` |

The helm chart and `values.yaml` (incl. the `#95` validator session-cache config) already track `master` on `inferno-prod`, so they are **already live on prod** — this PR does not change them.

## Risk flags
- **Dependencies / test kits** (`Gemfile.lock`): **unchanged** — `au_core_test_kit` 1.4.2 + same AU PS pin.
- **App code / static site** (`web/`, `lib/`): **unchanged**.
- **Chart** (`infra/**`): unchanged by this PR (already synced to prod independently).
- **Net effect:** a rolling pod restart onto a functionally-identical (released-flavour) image. **No behaviour change.**

## Changelog since current prod (`c983b73` → `0e151a2`)
The image delta is comment-only; the range is the Phase 2/3 platform work (CI/CD, preview envs, chart, docs), all non-image:
- **Phase 3 trunk cutover** — #92 (dev→master), #93 (trunk build workflow), #96 + #97 (write-back fixes), #98 (tidy-up)
- **Phase 2 preview environments** — #83, #84, #85, #86, #87, #89
- **`quality-control` PR gate** — #90
- **Validator session-cache** — #95 (config only; already live on prod via chart sync)
- **Docs** — #91 (Phase 3 runbook), #94 (Dockerfile comment)

Full diff: https://github.com/hl7au/au-fhir-inferno/compare/c983b73547f1f3a47f344ee7210b6c6cde5bf7da...0e151a206378d921fdebbe653db08a326f5a70ac