### PR TITLE
ci: scope promotion chart risk-flag to real chart changes

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -175,7 +175,9 @@ jobs:
           flag() { printf '%s\n' "$FILES" | grep -qE "$1" && echo '⚠️ CHANGED' || echo 'unchanged'; }
           DEPS=$(flag '^Gemfile\.lock$')
           APP_FLAG=$(flag '^(web|lib|app)/|\.rb$')
-          CHART=$(flag '^infra/')
+          # Chart = templates / base values.yaml / Chart.*, NOT the per-env values-{dev,prod}.yaml
+          # (those are just image-tag write-backs/promotions and would otherwise always trip).
+          CHART=$(flag '^infra/helm/inferno/(templates/|values\.yaml|Chart\.)')
 
           # Build the promotion branch (the actual values-prod.yaml image bump).
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Follow-up to #101. The chart risk-flag keyed on any `infra/**` change, so it tripped on **every** promotion — the diff range always includes the staging `values-dev.yaml` write-back and the prior `values-prod.yaml` promotion bump, both pure image-tag churn.

Scope the flag to the chart that affects the **prod render** — `templates/`, `values.yaml`, `Chart.*` — and ignore the per-env `values-{dev,prod}.yaml` tag files.

Verified against real ranges: churn-only `0e151a2..dae45f2` → `unchanged`; real-template-change `c983b73..0e151a2` → `⚠️ CHANGED`.