### PR TITLE
feat(validator): warmer / synthetic health-check CronJob

### DIFF
--- a/VALIDATOR_OPTIMIZATION.md
+++ b/VALIDATOR_OPTIMIZATION.md
@@ -250,6 +250,10 @@ CPU peaked **~2.0 / 3 cores** (no throttling), memory **flat ~9.5Gi / 12Gi** (no
 
 **Scaling guidance.** This validator keeps per-pod in-memory state with no shared/distributed cache and an expensive clone, so it cannot usefully cluster. To scale, raise `validator.resources` (vertical); scale-out would require a shared session cache or session-aware L7 routing (the session id lives in the request body, so standard proxies can't route on it) — neither exists today.
 
+**Two cold costs, not one (prod load test, fresh pod).** A no-prewarm prod run measured a cold *session* build of ~33s (small) / ~53s (large), then a single warm validation of ~3–4s — but `conc=10` of a large bundle took ~160–180s with CPU only ~1.7/3 cores. It's not CPU-bound: prod's terminology-cache PVC was fresh, so concurrent validations hit tx.dev for uncached codes and serialise. Dev did `conc=10` in ~13s only because its tx cache was thoroughly warm. So warming has **two** parts — the per-session engine build (held by the never-expire cache) and the **per-code terminology cache** (only warmed by actually validating representative bundles) — and the tx cache is what makes *concurrency* fast.
+
+**Warmer / synthetic health check** (`templates/validator-warmer.cronjob.yaml`, `warmer.*` values). A CronJob runs one `au_ps_bundle` validation through Inferno's real path every ~10 min. It warms **both** the session and the tx cache, and because it goes through Inferno it warms the *same* session id real users hit (a self-prewarm on the validator would use a throwaway id and not help Inferno's path, nor can `baseEngine` clone cheaply). It self-heals after a validator restart and doubles as an end-to-end synthetic check (the Job fails on an unreachable/errored/timed-out chain). Before a high-load event, tighten `warmer.schedule` and/or validate the full example set so the tx cache is fully warm.
+
 **Useful wrapper ops endpoints:** `GET /validator/presets` (loaded base engines), `/validator/engines` (cached sessions), `/txStatus`, `/packStatus`, `/validator/version`.
 
 ## Managing PVCs

--- a/infra/helm/inferno/files/warmer-bundle.json
+++ b/infra/helm/inferno/files/warmer-bundle.json
@@ -1,0 +1,578 @@
+{
+  "resourceType" : "Bundle",
+  "id" : "aups-basicsummary",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"]
+  },
+  "language" : "en-AU",
+  "identifier" : {
+    "system" : "urn:ietf:rfc:3986",
+    "value" : "urn:uuid:0bd27fed-5f11-4344-beeb-c3b78c00f604"
+  },
+  "type" : "document",
+  "timestamp" : "2025-02-05T19:33:11.0607701+10:00",
+  "entry" : [{
+    "fullUrl" : "urn:uuid:c5359ef2-ef27-445a-833a-c53e6bb437c5",
+    "resource" : {
+      "resourceType" : "Composition",
+      "id" : "c5359ef2-ef27-445a-833a-c53e6bb437c5",
+      "meta" : {
+        "versionId" : "1"
+      },
+      "language" : "en-AU",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\"><a name=\"Composition_c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Composition c5359ef2-ef27-445a-833a-c53e6bb437c5</b></p><a name=\"c5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><a name=\"hcc5359ef2-ef27-445a-833a-c53e6bb437c5\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">version: 1; Language: en-AU</p></div><p><b>status</b>: Final</p><p><b>type</b>: <span title=\"Codes:{http://loinc.org 60591-5}\">Patient summary Document</span></p><p><b>date</b>: 2025-02-03</p><p><b>author</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-463c2982-3759-4022-b40e-521bbe54d544\">PractitionerRole General practitioner</a></p><p><b>title</b>: Australian Patient Summary</p><p><b>custodian</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p></div>"
+      },
+      "status" : "final",
+      "type" : {
+        "coding" : [{
+          "system" : "http://loinc.org",
+          "code" : "60591-5",
+          "display" : "Patient summary Document"
+        }]
+      },
+      "subject" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "date" : "2025-02-03",
+      "author" : [{
+        "reference" : "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544"
+      }],
+      "title" : "Australian Patient Summary",
+      "custodian" : {
+        "reference" : "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+      },
+      "section" : [{
+        "title" : "Active Problems",
+        "code" : {
+          "coding" : [{
+            "system" : "http://loinc.org",
+            "code" : "11450-4",
+            "display" : "Problem list - Reported"
+          }]
+        },
+        "text" : {
+          "status" : "generated",
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">21/12/2024 No current problem or disability.</div>"
+        },
+        "entry" : [{
+          "reference" : "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d"
+        }]
+      },
+      {
+        "title" : "Active Allergies or Intolerances",
+        "code" : {
+          "coding" : [{
+            "system" : "http://loinc.org",
+            "code" : "48765-2",
+            "display" : "Allergies and adverse reactions Document"
+          }]
+        },
+        "text" : {
+          "status" : "generated",
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n            <table border=\"1\">\n              <thead>\n                <tr>\n                  <th>Allergy, Intolerance, Substance</th>\n                  <th>Onset</th>\n                  <th>Recorded</th>\n                  <th>Manifestation</th>\n                  <th>Manifestation Severity</th>\n                </tr>\n              </thead>\n              <tbody>\n                <tr>\n                  <td>Intolerance to lactose</td>\n                  <td>2022</td>\n                  <td>14/03/2023</td>\n                  <td>Abdominal pain, Abdominal bloating, Diarrhoea</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Gluten intolerance</td>\n                  <td>1999</td>\n                  <td>12/01/2023</td>\n                  <td>Fatigue</td>\n                  <td>Mild</td>\n                </tr>\n                <tr>\n                  <td>Chlorhexidine</td>\n                  <td>12/01/2023</td>\n                  <td>09/09/2023</td>\n                  <td>Hives</td>\n                  <td>Mild</td>\n                </tr>\n              </tbody>\n            </table>\n            </div>"
+        },
+        "entry" : [{
+          "reference" : "urn:uuid:ad6fb7b7-c76f-441e-88a5-9051e795db26"
+        },
+        {
+          "reference" : "urn:uuid:06ba95f5-345b-412d-aa66-99e354470015"
+        },
+        {
+          "reference" : "urn:uuid:d24db2d5-3400-4158-892c-d018acdeba09"
+        }]
+      },
+      {
+        "title" : "Current Medicines",
+        "code" : {
+          "coding" : [{
+            "system" : "http://loinc.org",
+            "code" : "10160-0",
+            "display" : "History of Medication use Narrative"
+          }]
+        },
+        "text" : {
+          "status" : "generated",
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-AU\" lang=\"en-AU\">\n              <table border=\"1\">\n                <thead>\n                  <tr>\n                    <th>Medicine</th>\n                    <th>Directions</th>\n                    <th>Date asserted</th>\n                  </tr>\n                </thead>\n                <tbody>\n                  <tr>\n                    <td><b>Bisoprolol</b> 2.5mg tab</td>\n                    <td>Take 1/2 tablet in the morning</td>\n                    <td>05/01/2025</td>\n                  </tr>\n                </tbody>\n              </table>\n            </div>"
+        },
+        "entry" : [{
+          "reference" : "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1"
+        }]
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "9be88cc6-09e8-4dc6-b058-88676240dbc7",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Patient 9be88cc6-09e8-4dc6-b058-88676240dbc7</b></p><a name=\"9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><a name=\"hc9be88cc6-09e8-4dc6-b058-88676240dbc7\"> </a><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Detail</td><td colspan=\"3\"><ul><li>ph: 0270102724(Work)</li><li>ph: 0491574632(Mobile)</li><li>ph: 0270107520(Home)</li><li><a href=\"mailto:mia.banks@myownpersonaldomain.com\">mia.banks@myownpersonaldomain.com</a></li><li>ph: 270107520(Home)</li><li>50 Sebastien St Minjary NSW 2720 AU </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The pronouns to use when referring to an individual in verbal or written communication.\">Individual Pronouns:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://loinc.org LA29519-8}\">she/her/her/hers/herself</span></li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"An individual's personal sense of being a man, woman, boy, girl, nonbinary, or something else. This represents an individual’s identity, ascertained by asking them what that identity is. \n In the case where the gender identity is communicated by a third party, for example, if a spouse indicates the gender identity of their partner on an intake form, a Provenance resource can be used with a Provenance.target referring to the Patient, with a targetElement extension identifying the gender identity extension as the target element within the Patient resource.  When exchanging this concept, refer to the guidance in the [Gender Harmony Implementation Guide](http://hl7.org/xprod/ig/uv/gender-harmony/).\">Individual Gender Identity:</td><td colspan=\"3\"><ul><li>value: <span title=\"Codes:{http://snomed.info/sct 446141000124107}\">Identifies as female gender</span></li></ul></td></tr></table></div>"
+      },
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity",
+        "extension" : [{
+          "url" : "value",
+          "valueCodeableConcept" : {
+            "coding" : [{
+              "system" : "http://snomed.info/sct",
+              "code" : "446141000124107",
+              "display" : "Identifies as female gender"
+            }]
+          }
+        }]
+      },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/individual-pronouns",
+        "extension" : [{
+          "url" : "value",
+          "valueCodeableConcept" : {
+            "coding" : [{
+              "system" : "http://loinc.org",
+              "code" : "LA29519-8",
+              "display" : "she/her/her/hers/herself"
+            }]
+          }
+        }]
+      }],
+      "identifier" : [{
+        "extension" : [{
+          "url" : "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding" : {
+            "system" : "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code" : "active"
+          }
+        },
+        {
+          "url" : "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding" : {
+            "system" : "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code" : "verified",
+            "display" : "verified"
+          }
+        }],
+        "type" : {
+          "coding" : [{
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "NI"
+          }],
+          "text" : "IHI"
+        },
+        "system" : "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+        "value" : "8003608333647261"
+      }],
+      "name" : [{
+        "use" : "usual",
+        "family" : "Banks",
+        "given" : ["Mia",
+        "Leanne"]
+      }],
+      "telecom" : [{
+        "system" : "phone",
+        "value" : "0270102724",
+        "use" : "work"
+      },
+      {
+        "system" : "phone",
+        "value" : "0491574632",
+        "use" : "mobile"
+      },
+      {
+        "system" : "phone",
+        "value" : "0270107520",
+        "use" : "home"
+      },
+      {
+        "system" : "email",
+        "value" : "mia.banks@myownpersonaldomain.com"
+      },
+      {
+        "system" : "phone",
+        "value" : "270107520",
+        "use" : "home"
+      }],
+      "gender" : "female",
+      "birthDate" : "1983-08-25",
+      "address" : [{
+        "line" : ["50 Sebastien St"],
+        "city" : "Minjary",
+        "state" : "NSW",
+        "postalCode" : "2720",
+        "country" : "AU"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "70a756e3-20b3-4637-8601-a222983e295a",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_70a756e3-20b3-4637-8601-a222983e295a\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Organization 70a756e3-20b3-4637-8601-a222983e295a</b></p><a name=\"70a756e3-20b3-4637-8601-a222983e295a\"> </a><a name=\"hc70a756e3-20b3-4637-8601-a222983e295a\"> </a><p><b>identifier</b>: ABN/12345678901</p><p><b>type</b>: <span title=\"Codes:{http://snomed.info/sct 288565001}\">Medical Center</span></p><p><b>name</b>: Bobrester Medical Center</p><p><b>telecom</b>: <a href=\"mailto:info@bobrestermedical.example.com\">info@bobrestermedical.example.com</a>, ph: (07) 5550 2427(Work)</p><p><b>address</b>: 87 Western Esp Tindal RAAF QLD 4655 AU </p></div>"
+      },
+      "identifier" : [{
+        "type" : {
+          "coding" : [{
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "XX"
+          }],
+          "text" : "ABN"
+        },
+        "system" : "http://hl7.org.au/id/abn",
+        "value" : "12345678901"
+      }],
+      "type" : [{
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "288565001",
+          "display" : "Medical centre"
+        }],
+        "text" : "Medical Center"
+      }],
+      "name" : "Bobrester Medical Center",
+      "telecom" : [{
+        "system" : "email",
+        "value" : "info@bobrestermedical.example.com",
+        "use" : "work"
+      },
+      {
+        "system" : "phone",
+        "value" : "(07) 5550 2427",
+        "use" : "work"
+      }],
+      "address" : [{
+        "line" : ["87 Western Esp"],
+        "city" : "Tindal RAAF",
+        "state" : "QLD",
+        "postalCode" : "4655",
+        "country" : "AU"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:463c2982-3759-4022-b40e-521bbe54d544",
+    "resource" : {
+      "resourceType" : "PractitionerRole",
+      "id" : "463c2982-3759-4022-b40e-521bbe54d544",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"PractitionerRole_463c2982-3759-4022-b40e-521bbe54d544\"> </a><p class=\"res-header-id\"><b>Generated Narrative: PractitionerRole 463c2982-3759-4022-b40e-521bbe54d544</b></p><a name=\"463c2982-3759-4022-b40e-521bbe54d544\"> </a><a name=\"hc463c2982-3759-4022-b40e-521bbe54d544\"> </a><p><b>identifier</b>: Employee Number/12345678</p><p><b>practitioner</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-dce50472-2a94-47e6-9501-b52f0df0c813\">Practitioner Bob Bobrester </a></p><p><b>organization</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-70a756e3-20b3-4637-8601-a222983e295a\">Organization Bobrester Medical Center</a></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 62247001}, {http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0 253111}\">General Practitioner</span></p><p><b>telecom</b>: ph: 0491579760, <a href=\"mailto:drbob@bobrestermedical.example.com\">drbob@bobrestermedical.example.com</a></p></div>"
+      },
+      "identifier" : [{
+        "type" : {
+          "coding" : [{
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "EI",
+            "display" : "Employee number"
+          }],
+          "text" : "Employee Number"
+        },
+        "system" : "http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/12345678901",
+        "value" : "12345678",
+        "assigner" : {
+          "display" : "Bobrester Medical Center"
+        }
+      }],
+      "practitioner" : {
+        "reference" : "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813"
+      },
+      "organization" : {
+        "reference" : "urn:uuid:70a756e3-20b3-4637-8601-a222983e295a"
+      },
+      "code" : [{
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "62247001"
+        },
+        {
+          "system" : "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0",
+          "code" : "253111"
+        }],
+        "text" : "General Practitioner"
+      }],
+      "telecom" : [{
+        "system" : "phone",
+        "value" : "0491579760"
+      },
+      {
+        "system" : "email",
+        "value" : "drbob@bobrestermedical.example.com"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:dce50472-2a94-47e6-9501-b52f0df0c813",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "dce50472-2a94-47e6-9501-b52f0df0c813",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Practitioner_dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Practitioner dce50472-2a94-47e6-9501-b52f0df0c813</b></p><a name=\"dce50472-2a94-47e6-9501-b52f0df0c813\"> </a><a name=\"hcdce50472-2a94-47e6-9501-b52f0df0c813\"> </a><p><b>name</b>: Bob Bobrester </p></div>"
+      },
+      "name" : [{
+        "family" : "Bobrester",
+        "given" : ["Bob"],
+        "prefix" : ["Dr."]
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:ad6fb7b7-c76f-441e-88a5-9051e795db26",
+    "resource" : {
+      "resourceType" : "AllergyIntolerance",
+      "id" : "ad6fb7b7-c76f-441e-88a5-9051e795db26",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance ad6fb7b7-c76f-441e-88a5-9051e795db26</b></p><a name=\"ad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><a name=\"hcad6fb7b7-c76f-441e-88a5-9051e795db26\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>verificationStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-verification confirmed}\">Confirmed</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 782415009}\">Intolerance to lactose</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2022</p><p><b>recordedDate</b>: 2023-03-14</p><blockquote><p><b>reaction</b></p><p><b>manifestation</b>: <span title=\"Codes:{http://snomed.info/sct 21522001}\">Abdominal pain</span>, <span title=\"Codes:{http://snomed.info/sct 116289008}\">Abdominal bloating</span>, <span title=\"Codes:{http://snomed.info/sct 62315008}\">Diarrhoea</span></p><p><b>severity</b>: Mild</p></blockquote></div>"
+      },
+      "clinicalStatus" : {
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "code" : "active",
+          "display" : "Active"
+        }]
+      },
+      "verificationStatus" : {
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+          "code" : "confirmed",
+          "display" : "Confirmed"
+        }]
+      },
+      "code" : {
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "782415009",
+          "display" : "Intolerance to lactose"
+        }]
+      },
+      "patient" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "onsetDateTime" : "2022",
+      "recordedDate" : "2023-03-14",
+      "reaction" : [{
+        "manifestation" : [{
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "21522001",
+            "display" : "Abdominal pain"
+          }]
+        },
+        {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "116289008",
+            "display" : "Abdominal bloating"
+          }]
+        },
+        {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "62315008",
+            "display" : "Diarrhoea"
+          }]
+        }],
+        "severity" : "mild"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:06ba95f5-345b-412d-aa66-99e354470015",
+    "resource" : {
+      "resourceType" : "AllergyIntolerance",
+      "id" : "06ba95f5-345b-412d-aa66-99e354470015",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_06ba95f5-345b-412d-aa66-99e354470015\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance 06ba95f5-345b-412d-aa66-99e354470015</b></p><a name=\"06ba95f5-345b-412d-aa66-99e354470015\"> </a><a name=\"hc06ba95f5-345b-412d-aa66-99e354470015\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>type</b>: Intolerance</p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 1269424006}\">Gluten intolerance</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 1999</p><p><b>recordedDate</b>: 2023-01-12</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 89811004}\">Gluten</span></td><td><span title=\"Codes:{http://snomed.info/sct 84229001}\">Fatigue</span></td><td>Mild</td></tr></table></div>"
+      },
+      "clinicalStatus" : {
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "code" : "active"
+        }],
+        "text" : "Active"
+      },
+      "type" : "intolerance",
+      "code" : {
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "1269424006"
+        }],
+        "text" : "Gluten intolerance"
+      },
+      "patient" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "onsetDateTime" : "1999",
+      "recordedDate" : "2023-01-12",
+      "reaction" : [{
+        "substance" : {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "89811004"
+          }],
+          "text" : "Gluten"
+        },
+        "manifestation" : [{
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "84229001"
+          }],
+          "text" : "Fatigue"
+        }],
+        "severity" : "mild"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:d24db2d5-3400-4158-892c-d018acdeba09",
+    "resource" : {
+      "resourceType" : "AllergyIntolerance",
+      "id" : "d24db2d5-3400-4158-892c-d018acdeba09",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"AllergyIntolerance_d24db2d5-3400-4158-892c-d018acdeba09\"> </a><p class=\"res-header-id\"><b>Generated Narrative: AllergyIntolerance d24db2d5-3400-4158-892c-d018acdeba09</b></p><a name=\"d24db2d5-3400-4158-892c-d018acdeba09\"> </a><a name=\"hcd24db2d5-3400-4158-892c-d018acdeba09\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical active}\">Active</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></p><p><b>patient</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>onset</b>: 2023-01-12</p><p><b>recordedDate</b>: 2023-09-09</p><h3>Reactions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Substance</b></td><td><b>Manifestation</b></td><td><b>Severity</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 373568007}\">Chlorhexidine</span></td><td><span title=\"Codes:{http://snomed.info/sct 247472004}\">Hives</span></td><td>Mild</td></tr></table></div>"
+      },
+      "clinicalStatus" : {
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          "code" : "active"
+        }],
+        "text" : "Active"
+      },
+      "code" : {
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "373568007"
+        }],
+        "text" : "Chlorhexidine"
+      },
+      "patient" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "onsetDateTime" : "2023-01-12",
+      "recordedDate" : "2023-09-09",
+      "reaction" : [{
+        "substance" : {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "373568007"
+          }],
+          "text" : "Chlorhexidine"
+        },
+        "manifestation" : [{
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "247472004"
+          }],
+          "text" : "Hives"
+        }],
+        "severity" : "mild"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:347e8435-cea1-4e94-9755-abb027926bb1",
+    "resource" : {
+      "resourceType" : "MedicationStatement",
+      "id" : "347e8435-cea1-4e94-9755-abb027926bb1",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"MedicationStatement_347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p class=\"res-header-id\"><b>Generated Narrative: MedicationStatement 347e8435-cea1-4e94-9755-abb027926bb1</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1\"> </a><p><b>status</b>: Active</p><p><b>medication</b>: <a href=\"#hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\">Medication Bisoprolol fumarate 2.5 mg tablet</a></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>effective</b>: 2025-01-05</p><p><b>dateAsserted</b>: 2025-01-05</p><h3>Dosages</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Text</b></td></tr><tr><td style=\"display: none\">*</td><td>1/2 tablet in the morning</td></tr></table><hr/><blockquote><p class=\"res-header-id\"><b>Generated Narrative: Medication #bisoprolol</b></p><a name=\"347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><a name=\"hc347e8435-cea1-4e94-9755-abb027926bb1/bisoprolol\"> </a><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 23281011000036106}\">Bisoprolol 2.5mg tab</span></p><p><b>form</b>: <span title=\"Codes:{http://snomed.info/sct 385055001}\">Tablet</span></p><h3>Ingredients</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 386869006}\">Bisoprolol fumarate</span></td><td>2.5 mg<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM  codemg = 'mg')</span>/1 Tablet<span style=\"background: LightGoldenRodYellow\"> (Details: SNOMED CT  code385055001 = 'Tablet')</span></td></tr></table></blockquote></div>"
+      },
+      "contained" : [{
+        "resourceType" : "Medication",
+        "id" : "bisoprolol",
+        "code" : {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "23281011000036106",
+            "display" : "Bisoprolol fumarate 2.5 mg tablet"
+          }],
+          "text" : "Bisoprolol 2.5mg tab"
+        },
+        "form" : {
+          "coding" : [{
+            "system" : "http://snomed.info/sct",
+            "code" : "385055001",
+            "display" : "Tablet"
+          }]
+        },
+        "ingredient" : [{
+          "itemCodeableConcept" : {
+            "coding" : [{
+              "system" : "http://snomed.info/sct",
+              "code" : "386869006",
+              "display" : "Bisoprolol fumarate"
+            }]
+          },
+          "strength" : {
+            "numerator" : {
+              "value" : 2.5,
+              "system" : "http://unitsofmeasure.org",
+              "code" : "mg"
+            },
+            "denominator" : {
+              "value" : 1,
+              "unit" : "Tablet",
+              "system" : "http://snomed.info/sct",
+              "code" : "385055001"
+            }
+          }
+        }]
+      }],
+      "status" : "active",
+      "medicationReference" : {
+        "reference" : "#bisoprolol"
+      },
+      "subject" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "effectiveDateTime" : "2025-01-05",
+      "dateAsserted" : "2025-01-05",
+      "dosage" : [{
+        "text" : "1/2 tablet in the morning"
+      }]
+    }
+  },
+  {
+    "fullUrl" : "urn:uuid:310f1593-d610-4144-a6e8-1f823d955e0d",
+    "resource" : {
+      "resourceType" : "Condition",
+      "id" : "310f1593-d610-4144-a6e8-1f823d955e0d",
+      "text" : {
+        "status" : "generated",
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p class=\"res-header-id\"><b>Generated Narrative: Condition 310f1593-d610-4144-a6e8-1f823d955e0d</b></p><a name=\"310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><a name=\"hc310f1593-d610-4144-a6e8-1f823d955e0d\"> </a><p><b>clinicalStatus</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-clinical active}\">Active</span></p><p><b>category</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/condition-category problem-list-item}\">Problem List Item</span></p><p><b>code</b>: <span title=\"Codes:{http://snomed.info/sct 160245001}\">No current problems or disability</span></p><p><b>subject</b>: <a href=\"Bundle-aups-basicsummary.html#urn-uuid-9be88cc6-09e8-4dc6-b058-88676240dbc7\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>recordedDate</b>: 2024-12-21</p></div>"
+      },
+      "clinicalStatus" : {
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "code" : "active",
+          "display" : "Active"
+        }]
+      },
+      "category" : [{
+        "coding" : [{
+          "system" : "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code" : "problem-list-item",
+          "display" : "Problem List Item"
+        }]
+      }],
+      "code" : {
+        "coding" : [{
+          "system" : "http://snomed.info/sct",
+          "code" : "160245001",
+          "display" : "No current problems or disability"
+        }]
+      },
+      "subject" : {
+        "reference" : "urn:uuid:9be88cc6-09e8-4dc6-b058-88676240dbc7"
+      },
+      "recordedDate" : "2024-12-21"
+    }
+  }]
+}

--- a/infra/helm/inferno/files/warmer.py
+++ b/infra/helm/inferno/files/warmer.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Validator warmer / synthetic health check.
+
+Runs one au_ps_bundle validation through Inferno's real API path
+(Inferno -> worker -> validator -> tx server). Serves two purposes:
+
+  1. WARM-UP: keeps the validator's session engine and terminology cache hot, and
+     re-warms them after a validator pod restart. Because it goes through Inferno it
+     warms the *same* validator session id real users hit (a self-prewarm on the
+     validator would use a throwaway id and not help Inferno's path).
+  2. SYNTHETIC HEALTH CHECK: exercises the full validation chain end to end on a
+     schedule. Exits non-zero on an infrastructure failure (unreachable, run errored,
+     timeout) so the CronJob surfaces it; benign validation warnings/errors in the
+     bundle do NOT fail the check (those are data-dependent and expected).
+
+Stdlib only. Config via env: INFERNO_URL, TEST_SUITE_ID, PROFILE, BUNDLE_PATH, POLL_TIMEOUT.
+"""
+import json, os, sys, time, urllib.request, urllib.error
+
+URL = os.environ.get("INFERNO_URL", "http://inferno:4567").rstrip("/")
+SUITE = os.environ.get("TEST_SUITE_ID", "suite_100preview")
+PROFILE = os.environ.get("PROFILE", "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle")
+BUNDLE_PATH = os.environ.get("BUNDLE_PATH", "/warmer/warmer-bundle.json")
+POLL_TIMEOUT = int(os.environ.get("POLL_TIMEOUT", "300"))
+API = f"{URL}/suites/api"
+
+
+def http(method, path, body=None, timeout=60):
+    req = urllib.request.Request(API + path, method=method,
+                                 data=(body.encode() if body else None),
+                                 headers={"Content-Type": "application/json", "Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode() or "{}")
+
+
+def fail(msg):
+    print(f"warmer UNHEALTHY: {msg}", flush=True)
+    sys.exit(1)
+
+
+def main():
+    t0 = time.time()
+    bundle = open(BUNDLE_PATH).read()
+    try:
+        session = http("POST", f"/test_sessions?test_suite_id={SUITE}",
+                       json.dumps({"preset_id": None, "suite_options": []}))["id"]
+        run = http("POST", "/test_runs", json.dumps({
+            "test_session_id": session, "test_suite_id": SUITE, "inputs": [
+                {"name": "validate_against", "value": json.dumps(["au_ps_bundle"]), "type": "text"},
+                {"name": "bundle_resource", "value": bundle, "type": "text"},
+                {"name": "profile", "value": PROFILE, "type": "text"},
+            ]}))["id"]
+    except (urllib.error.URLError, KeyError, ValueError) as e:
+        fail(f"could not start validation: {e}")
+
+    deadline = time.time() + POLL_TIMEOUT
+    status = None
+    while time.time() < deadline:
+        try:
+            status = http("GET", f"/test_runs/{run}").get("status")
+        except urllib.error.URLError as e:
+            fail(f"polling failed: {e}")
+        if status in ("done", "cancelled"):
+            break
+        time.sleep(2)
+    else:
+        fail(f"validation did not finish within {POLL_TIMEOUT}s (last status={status})")
+
+    elapsed = time.time() - t0
+    results = http("GET", f"/test_runs/{run}/results")
+    counts = {}
+    for r in results:
+        counts[r.get("result", "?")] = counts.get(r.get("result", "?"), 0) + 1
+    # "error" results indicate the run could not execute (infra), not data validation failures.
+    errored = counts.get("error", 0)
+    print(f"warmer OK: suite={SUITE} status={status} elapsed={elapsed:.1f}s results={dict(sorted(counts.items()))}", flush=True)
+    if errored:
+        fail(f"{errored} test(s) errored (infrastructure)")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
+++ b/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.warmer.enabled }}
+# Validator warmer / synthetic health check. Periodically runs one au_ps_bundle
+# validation through Inferno's real API path (Inferno -> worker -> validator -> tx),
+# which (1) keeps the validator's session engine + terminology cache warm and re-warms
+# them after a validator pod restart — going through Inferno warms the *same* session id
+# real users hit, which a self-prewarm on the validator can't do — and (2) acts as an
+# end-to-end synthetic check (the Job fails if the chain is unreachable/errors/times out).
+# The never-expire session cache keeps things warm between runs, so a modest cadence is
+# enough; raise warmer.schedule frequency (and run the full example set manually) to fully
+# warm the terminology cache before an event. See docs/VALIDATOR_OPTIMIZATION.md.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: validator-warmer
+  namespace: {{ .Release.Namespace }}
+data:
+  warmer.py: |
+{{ .Files.Get "files/warmer.py" | indent 4 }}
+  warmer-bundle.json: |
+{{ .Files.Get "files/warmer-bundle.json" | indent 4 }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: validator-warmer
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: {{ .Values.warmer.schedule | quote }}
+  concurrencyPolicy: Forbid            # never overlap warmer runs
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: {{ add (.Values.warmer.pollTimeout | int) 120 }}
+      template:
+        metadata:
+          labels:
+            app: validator-warmer
+        spec:
+          restartPolicy: Never
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          volumes:
+          - name: warmer
+            configMap:
+              name: validator-warmer
+          containers:
+          - name: warmer
+            image: {{ .Values.warmer.image | quote }}
+            command: ["python3", "/warmer/warmer.py"]
+            env:
+            - name: INFERNO_URL
+              value: {{ .Values.warmer.infernoUrl | quote }}
+            - name: TEST_SUITE_ID
+              value: {{ .Values.warmer.testSuiteId | quote }}
+            - name: PROFILE
+              value: {{ .Values.warmer.profile | quote }}
+            - name: BUNDLE_PATH
+              value: /warmer/warmer-bundle.json
+            - name: POLL_TIMEOUT
+              value: {{ .Values.warmer.pollTimeout | quote }}
+            volumeMounts:
+            - name: warmer
+              mountPath: /warmer
+              readOnly: true
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "50m"
+              limits:
+                memory: "128Mi"
+                cpu: "250m"
+{{- end }}

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -69,6 +69,21 @@ validator:
 # For a known high-load event, raise validator.resources rather than replicas.
 # See docs/VALIDATOR_OPTIMIZATION.md.
 
+# Validator warmer / synthetic health check (templates/validator-warmer.cronjob.yaml).
+# Periodically runs one au_ps_bundle validation through Inferno's real path, which keeps
+# the validator session + terminology cache warm (and re-warms after a pod restart, since
+# going through Inferno warms the same session id real users hit), and doubles as an
+# end-to-end synthetic check. The never-expire session cache holds warmth between runs, so
+# every 10 min is plenty; tighten before an event to fully warm the tx cache.
+warmer:
+  enabled: true
+  schedule: "*/10 * * * *"
+  image: "python:3.12-slim"
+  infernoUrl: "http://inferno:4567"   # in-cluster; /suites proxies here
+  testSuiteId: "suite_100preview"
+  profile: "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"
+  pollTimeout: 300
+
 postgresql:
   enabled: false # enable if not using rds from aws-impl
   externaldbhost: null # This can be overridden during chart deployment


### PR DESCRIPTION
## Why

A no-prewarm prod load test (fresh pod, after the StatefulSet→Deployment cutover) found **two** cold costs, not one:
1. **Session engine build** (~33s small / ~53s large) — held warm afterwards by the never-expire cache.
2. **Per-code terminology cache** — the bigger event risk. On a fresh pod, concurrent validations hit tx.dev for uncached codes and **serialise**: `conc=10` large ≈ **160–180s** with CPU only **~1.7/3 cores** (not CPU-bound). A fully warm tx cache does the same in **~13s** (dev).

A self-prewarm on the validator can't fix this for real traffic: it would build a session under a throwaway id (Inferno reuses its own stored id), and `baseEngine` can't clone cheaply on the deployed core (6.6.3/6.9.7). The fix has to go **through Inferno**.

## What

A CronJob (default `*/10 * * * *`) runs one `au_ps_bundle` validation through Inferno's real path (`http://inferno:4567/suites/api`). It:
- **Warms both** the session *and* the terminology cache, under the **same session id** real users hit.
- **Self-heals** after a validator pod restart (next run re-warms).
- Doubles as an **end-to-end synthetic health check** — the Job exits non-zero on an unreachable / errored / timed-out chain; benign validation warnings don't fail it.

Script + a representative bundle ship via ConfigMap (`.Files.Get`); runs on a small `python:3.12-slim` pod (stdlib only). All knobs values-driven: `warmer.enabled/schedule/image/infernoUrl/testSuiteId/profile/pollTimeout`.

## Notes
- **Before a high-load event:** tighten `warmer.schedule` and/or validate the full example set so the tx cache is fully warm (one bundle warms its codes only).
- Each run creates a throwaway Inferno test session (lightweight rows; the valuable thing — the shared validator session — is refreshed). Prunable.
- Previews can set `warmer.enabled: false` if not wanted.
- Smoke-tested against dev: `warmer OK … status=done … 94 pass/33 skip/2 omit`, exit 0.
- `helm template` verified (ConfigMap+CronJob render; `warmer.enabled=false` renders nothing).

Follows the single-pod Deployment refactor (#103).