### PR TITLE
fix(perf): gate banner performance link/strip on PERFORMANCE_MONITORING_ENABLED

### DIFF
--- a/config/banner.html.erb
+++ b/config/banner.html.erb
@@ -1,3 +1,7 @@
+<%# Performance UI (header link + per-session strip) is gated on the same flag as the
+    /performance backend (config.ru). Kept off in prod so the link/strip aren't injected
+    on pages where /performance and /api/performance return 404. %>
+<% perf_enabled = ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true' %>
 <div class="header">
   <!-- Web banner -->
   <div class="container header-container-outer header-container-web">
@@ -7,11 +11,13 @@
           <span class="header-title">Inferno on hl7.org.au</span>
         </a>
       </div>
+      <% if perf_enabled %>
       <div class="header-text web-header-text">
         <div>
           <a id="perf-link" href="/performance" style="opacity:0.6">Performance</a>
         </div>
       </div>
+      <% end %>
     </div>
   </div>
 
@@ -27,8 +33,10 @@
   </div>
 </div>
 
+<% if perf_enabled %>
 <!-- Performance strip — auto-populated when on a session page -->
 <div id="ipp-strip"></div>
+<% end %>
 
 <script type="text/javascript">
   /* Get local storage sessions */
@@ -89,6 +97,7 @@
     { subtree: true, characterData: true, childList: true }
   );
 
+  <% if perf_enabled %>
   /* Detect session ID and populate performance strip */
   (function() {
     const match = location.pathname.match(/\/test_sessions\/([^\/]+)/)
@@ -167,6 +176,7 @@
       })
       .catch(function() { strip.style.display = 'none'; });
   })();
+  <% end %>
 
   /* Open and close banner info */
   const toggleBannerInfo = () => {
@@ -256,6 +266,7 @@
     text-align: right;
   }
 
+  <% if perf_enabled %>
   /* ── Performance strip ─────────────────────────────────── */
   .ipp-strip {
     display: flex;
@@ -338,4 +349,5 @@
     margin-left: 4px;
   }
   .ipp-report-link:hover { text-decoration: underline !important; }
+  <% end %>
 </style>


### PR DESCRIPTION
## Problem

On prod, fresh test-session pages still showed a header **"Performance"** link that dead-links to `/performance` (404), despite the `config.ru` perf gate.

The gate (`PERFORMANCE_MONITORING_ENABLED=false`) correctly disables the backend — `/performance` and `/api/performance` return 404 and the request/validator timing middleware + dev-only migration never load. **But the "Performance" link is not part of that gate.** It comes from `config/banner.html.erb`, which inferno-core's `client_index.html.erb` injects into **every** client/session page whenever the file exists, independent of the flag. So on prod the header link 404'd and the per-session strip's `/api/performance` fetch always 404'd (it hid itself, but the header link stayed).

Verified live: a freshly created prod session (`au_core_v200`) rendered `id="perf-link" → /performance?session=…`. This was a current bug, not a stale-session artifact — purging old sessions would not have removed it.

## Change

Gate the perf-specific parts of `config/banner.html.erb` behind the same flag the backend uses:

- the header `<a id="perf-link">` link
- the `#ipp-strip` per-session strip
- the perf-detection `<script>` IIFE
- the `.ipp-*` CSS

via `<% perf_enabled = ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true' %>`. The banner is rendered in-process (`ERB.new(...).result`), so `ENV` is available at render time.

- **Prod** (`flag=false`): no performance UI rendered.
- **Dev/staging** (`flag=true`): unchanged — the perf backend is live there, so the link/strip stay.
- Banner title, recent-sessions logic, and info popover are untouched.

## Verification

- Rendered the ERB in both modes: `flag=false` drops all four perf pieces and keeps title / recent-sessions JS / info popover; `flag=true` keeps everything.
- `node --check` passes on the rendered `<script>` in both modes (no dangling braces from removing the IIFE).

## Deploy note

The banner is baked into the image, so this reaches prod via the normal trunk build → promotion PR, not a config-only redeploy.

## Unrelated observations confirmed (no change needed)

- **au_core is 1.4.2** on current prod (deployed gem + live API + fresh session all agree); the previously-seen "1.4.1" was a pre-deploy snapshot.
- **`suite_100preview`** is the AU PS 1.0.0-preview suite registered by `au_ps_inferno`; it is intentionally exposed and is depended on by the validator warmer and validator-session cache.