### PR TITLE
Promote prod → 06841a7

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:0e151a206378d921fdebbe653db08a326f5a70ac
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc
   usesWrapper: true
   validatorImageUri: markiantorno/validator-wrapper:1.0.68
 
@@ -22,7 +22,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:0e151a206378d921fdebbe653db08a326f5a70ac-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `0e151a2` → `06841a7` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **unchanged**
- App code / static site (`web/`, `lib/`): **unchanged**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`0e151a2`)
- ci: prefill prod-promotion PR with changelog + risk flags (#101)
- ci: scope promotion chart risk-flag to real chart changes (#102)
- refactor(validator): single-pod Deployment; remove HPA, pin service & affinity (#103)
- ci: remove staging write-back (ArgoCD Image Updater owns staging now) (#104)
- feat(validator): add warmer / synthetic health-check CronJob (#105)
- chore(warmer): run every 30 min instead of 10 (#106)
- docs: add validator benchmarking tool and session/cache reference (#99)
- fix(perf): gate banner performance link/strip on PERFORMANCE_MONITORING_ENABLED (#107)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/0e151a206378d921fdebbe653db08a326f5a70ac...06841a7b2713444b5951f29fead71d3064db88fc

- app:   `ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc-nginx`
