### PR TITLE
feat(au-core): default the AU Core test kit to v2.0.0

### DIFF
--- a/web/_test_kits/au-core.md
+++ b/web/_test_kits/au-core.md
@@ -5,15 +5,15 @@ test_kit_id: au_core_test_kit
 maturity: 1
 tags: [ AU ]
 date: 2026-03-09
-version: 1.4.1
+version: 1.4.2
 canonical_url: "http://hl7.org.au/fhir/core"
 logo: /assets/images/au-core-logo.png
 preview_text: The AU Core Test Kit validates the conformance of a server implementation to a specific version of the AU Core IG
 suites:
-  - title: AU Core v1.0.0
-    id: au_core_v100
   - title: AU Core v2.0.0
     id: au_core_v200
+  - title: AU Core v1.0.0
+    id: au_core_v100
 sections:
   - title: "Status"
     icon: /assets/images/checklist.svg


### PR DESCRIPTION
## What

Make **AU Core v2.0.0** the default (pre-selected) suite on the AU Core test-kit page at `/test-kits/au-core`. Previously AU Core v1.0.0 was pre-selected because it was listed first, and the `test-kit` layout marks the first suite (`forloop.first`) as the checked radio.

This reorders the `suites:` list in `web/_test_kits/au-core.md` so `au_core_v200` is first. AU Core v1.0.0 (`au_core_v100`) stays available as the second option.

## Why

AU Core 2.0.0 becomes the recommended/default version to test against from **01/07** (1 July). New testers landing on the page should start on v2.0.0 unless they deliberately pick v1.0.0.

## Scope note

The issue is filed on the test-kit repo (`au-fhir-core-inferno`), but the *default-suite selection* is a presentation concern owned by this site/harness repo (`au-fhir-inferno`) — the test-kit gem (1.4.x) already registers both `au_core_v100` and `au_core_v200`. No gem bump is needed.

## How to review

Add the `preview` label to this PR and open the per-PR environment — the AU Core test-kit page should show **AU Core v2.0.0** selected by default in the "Start Testing" panel.

Closes hl7au/au-fhir-core-inferno#285
