### PR TITLE
fix(redis): set fsGroup so RDB persistence works on fresh PVCs

### DIFF
--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -15,6 +15,16 @@ spec:
       labels:
         app: inferno-redis
     spec:
+      securityContext:
+        # redis:8.2-alpine runs the server as uid 999 / gid 1000 and does NOT chown a
+        # pre-existing /data mount, so a freshly-provisioned PVC stays root:root and the
+        # RDB bgsave fails ("Failed opening the temp RDB file ... Permission denied"),
+        # which trips stop-writes-on-bgsave-error and breaks test runs. fsGroup makes the
+        # volume group-owned by the redis gid and group-writable. This is why fresh volumes
+        # (every preview, and any reset dev volume) broke while prod's older redis-owned
+        # volume kept working. OnRootMismatch only re-applies when needed (cheap on existing).
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       nodeSelector:
         kubernetes.io/arch: amd64
         karpenter.sh/capacity-type: on-demand  # avoid spot reclamation taking the single-replica job queue down mid-run


### PR DESCRIPTION
## Symptom
Redis rejects writes on dev + preview environments; test runs fail and the UI shows `Failed to fetch`. Redis logs:
```
# Failed opening the temp RDB file temp-NNN.rdb (in server root dir /data) for saving: Permission denied
# Background saving error
MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk ...
```

## Cause
`redis:8.2-alpine` runs the server as **uid 999 / gid 1000** and does **not** chown a pre-existing `/data` mount. On a freshly-provisioned EBS volume `/data` stays `root:root`, so the bgsave child can't create its temp RDB → `stop-writes-on-bgsave-error` kicks in and Redis refuses writes.

Confirmed in-cluster:
| Env | `/data` owner | bgsave |
|---|---|---|
| prod | `redis:root` (older, already-initialised volume) | ✅ "DB saved on disk" |
| dev | `root:root` (reset volume) | ❌ Permission denied |
| preview `inferno-pr-*` | `root:root` (every fresh volume) | ❌ Permission denied |

So this bites **every fresh volume** — all previews, and dev whenever its volume is reset — while prod's older redis-owned volume kept working.

## Fix
Add a pod-level `securityContext.fsGroup: 1000` (the redis gid) with `fsGroupChangePolicy: OnRootMismatch`, so the kubelet makes the volume group-owned by redis and group-writable. Matches the `fsGroup: 1000` pattern already used by the validator deployment. Harmless to the already-working prod volume (one-time chgrp on next restart).

## Verification
`helm template` (dev/prod) + `helm lint` pass; the rendered `inferno-redis` Deployment carries the `fsGroup`. On merge, ArgoCD syncs dev automatically; previews pick it up on their next chart sync.