### PR TITLE
fix(deps): pin connection_pool to 2.x for Sidekiq 7.2.4 compatibility

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -22,6 +22,13 @@ gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'b7
 gem 'sinatra'
 gem 'sidekiq-cron'
 
+# Pin connection_pool to the 2.x line. Sidekiq 7.2.4 calls TimedStack#pop with a
+# positional timeout, but connection_pool 3.0 made that keyword-only, so 3.x raises
+# "wrong number of arguments (given 1, expected 0)" and kills Sidekiq's scheduler/cron
+# poller thread (e.g. the Old Session Deletion cron silently stops). Remove this pin once
+# Sidekiq is on >= 7.3, which adopted the connection_pool 3.0 API.
+gem 'connection_pool', '~> 2.5'
+
 # OpenTelemetry — worker emits spans to Alloy → Tempo
 gem 'opentelemetry-sdk'
 gem 'opentelemetry-exporter-otlp'

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -62,7 +62,7 @@ GEM
     coderay (1.1.3)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -536,6 +536,7 @@ PLATFORMS
 DEPENDENCIES
   au_core_test_kit!
   au_ps_inferno!
+  connection_pool (~> 2.5)
   database_cleaner-sequel (~> 1.8)
   factory_bot (~> 6.1)
   inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     coderay (1.1.3)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -530,6 +530,7 @@ PLATFORMS
 DEPENDENCIES
   au_core_test_kit (~> 1.4.0)
   au_ps_inferno!
+  connection_pool (~> 2.5)
   database_cleaner-sequel (~> 1.8)
   factory_bot (~> 6.1)
   inferno_core (~> 1.0.6)


### PR DESCRIPTION
## Problem
The worker logs an unhandled exception on boot:
```
ArgumentError: wrong number of arguments (given 1, expected 0)
  connection_pool-3.0.2/lib/connection_pool/timed_stack.rb:62:in 'pop'
  sidekiq-7.2.4/lib/sidekiq/scheduled.rb:226:in 'initial_wait'
```
`sidekiq (7.2.4)` declares only `connection_pool (>= 2.3.0)`, so bundler locked **`connection_pool 3.0.2`**. v3.0 made `TimedStack#pop`'s timeout keyword-only; Sidekiq 7.2.4 still calls it positionally → the **scheduler/cron poller thread dies**.

**Impact:** job processing is fine (test runs work), but **scheduled/cron jobs stop firing** — notably the **Old Session Deletion** cron — on **dev and prod** (both locks pinned 3.0.2). It's been failing quietly.

## Fix
Pin `connection_pool '~> 2.5'` in `Gemfile.common` (shared by `Gemfile` + `Gemfile.dev`) and regenerate both locks. Surgical: `3.0.2 → 2.5.5`, nothing else moved (au_core / au_ps pins unchanged). Remove once Sidekiq ≥ 7.3 (adopted the connection_pool 3.0 API).

## Verify
`bundle lock --update connection_pool` for both Gemfiles; diff is connection_pool-only. Labelling this PR `preview` would let us confirm the worker's Sidekiq scheduler boots clean (no ArgumentError) and the cron schedules, before merge.