### PR TITLE
fix(validator): disable inferno_core boot-time validator-session warming

### DIFF
--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -10,3 +10,10 @@ data:
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}
   RAILS_ENV: {{ default "production" .Values.inferno.railsEnv | quote }}
   PERFORMANCE_MONITORING_ENABLED: {{ .Values.inferno.performanceMonitoring | default false | quote }}
+  # Disable inferno_core's boot-time per-suite validator-session warming
+  # (config/boot/validator.rb). It validates a throwaway Patient for every suite; au_core_v100
+  # and au_core_v200 get handed the same validator sessionId, which collides on the
+  # validator_sessions table's unique validator_session_id index (save only handles the
+  # test_suite/options/validator conflict) and the job then retries forever. The dedicated
+  # validator-warmer CronJob keeps the real session hot through the actual API path instead.
+  INITIALIZE_VALIDATOR_SESSIONS: {{ .Values.inferno.initializeValidatorSessions | default false | quote }}


### PR DESCRIPTION
## Symptom
The worker floods with retrying `InvokeValidatorSession` failures:
```
Sequel::UniqueConstraintViolation: PG::UniqueViolation: duplicate key value violates
unique constraint "validator_sessions_validator_session_id_index"
DETAIL: Key (validator_session_id)=(3a34bc51-…) already exists.
```

## Cause
inferno_core's `config/boot/validator.rb` warms **every** suite on boot (`INITIALIZE_VALIDATOR_SESSIONS`, default `true`) by validating a throwaway `FHIR::Patient`. `au_core_v100` and `au_core_v200` are handed the **same** validator `sessionId`, but `validator_sessions` has a **unique index on `validator_session_id` alone**, and `ValidatorSessions#save` only does `ON CONFLICT (test_suite_id, suite_options, validator_name)` — so the second suite's INSERT collides and the job retries forever.

This was latent until the redis (#112) and connection_pool/Sidekiq (#113) fixes let these boot jobs actually run. Our `compose.yml` already disables it locally; the Helm configmap didn't, so in-cluster it defaulted to `true`.

**Not** a break in the real validation path — the dedicated `validator-warmer` CronJob (Inferno → worker → validator → tx) completes in ~8s, and test runs work.

## Fix
Set `INITIALIZE_VALIDATOR_SESSIONS=false` in the inferno configmap (overridable via `inferno.initializeValidatorSessions`, default `false`), matching `compose.yml`. The boot warmer is redundant with the warmer CronJob, which keeps the real session hot through the actual API path (the approach `VALIDATOR_OPTIMIZATION.md` endorses).

**Tradeoff:** au_core sessions won't be boot-pre-warmed (first au_core validation per pod is cold ~35s) — but that warming is already failing, so nothing working is lost. Extending the warmer CronJob to au_core is the cleaner way to pre-warm if desired.

**Upstream:** worth an inferno_core issue — the unique index on `validator_session_id` alone is too strict when suites legitimately share a session; `save` should handle that conflict.

## Verify
`helm template`/`lint` pass; renders `"false"` for dev/prod/preview.