### PR TITLE
fix(web): make session create + redirect host-agnostic (CORS + redirect)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -90,6 +90,14 @@ http {
     # Proxy to individual services
 
     location /suites {
+      # inferno_core builds absolute redirects from INFERNO_HOST, e.g. creating a session
+      # 302s /suites/test_sessions/<id> -> <INFERNO_HOST>/suites/<suite>/<id>. INFERNO_HOST
+      # is baked at build time, so under build-once (one image for staging + prod, and the
+      # dev-flavoured image for previews) that host is wrong for the environment actually
+      # serving the page and the user gets bounced to the wrong host. Rewrite absolute
+      # /suites redirects to relative so the browser resolves them against its current
+      # origin (scoped to /suites so external redirects, e.g. OAuth, are left untouched).
+      proxy_redirect ~^https?://[^/]+(/suites/.*)$ $1;
       proxy_pass http://inferno:4567;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,14 @@ http {
       default  off;
   }
 
+  # The scheme the client actually used. TLS terminates upstream (at the gateway), so
+  # nginx itself listens on http and $scheme is always "http"; trust X-Forwarded-Proto
+  # when present (deployed envs), falling back to $scheme for local/direct access.
+  map $http_x_forwarded_proto $fwd_scheme {
+      default  $http_x_forwarded_proto;
+      ""       $scheme;
+  }
+
   server {
     listen 80;
 
@@ -95,9 +103,10 @@ http {
       # is baked at build time, so under build-once (one image for staging + prod, and the
       # dev-flavoured image for previews) that host is wrong for the environment actually
       # serving the page and the user gets bounced to the wrong host. Rewrite absolute
-      # /suites redirects to relative so the browser resolves them against its current
-      # origin (scoped to /suites so external redirects, e.g. OAuth, are left untouched).
-      proxy_redirect ~^https?://[^/]+(/suites/.*)$ $1;
+      # /suites redirects to point at the host (and scheme) the client actually used, so
+      # the user stays on the environment they're on. Scoped to /suites so external
+      # redirects (e.g. OAuth) are left untouched.
+      proxy_redirect ~^https?://[^/]+(/suites/.*)$ $fwd_scheme://$host$1;
       proxy_pass http://inferno:4567;
     }
 

--- a/web/assets/scripts/config.js
+++ b/web/assets/scripts/config.js
@@ -1,5 +1,11 @@
 ---
 ---
 var siteConfig = {
-  infernoHost: "{{ site.inferno_host }}",
+  // Use the current origin so the static build is host-agnostic. The site, its API
+  // (/suites/api/...) and the session pages are always served from the SAME host
+  // (nginx proxies /suites to the inferno backend), so same-origin is always correct.
+  // Baking site.inferno_host broke things under the build-once model: staging and every
+  // preview ship the same image as prod, so the prod (or dev) host was hard-coded and the
+  // UI POSTed cross-origin to a different host, which the browser blocks via CORS.
+  infernoHost: window.location.origin,
 };


### PR DESCRIPTION
Fixes session creation being broken on **dev** and **previews** by the build-once baked host. Two halves of the same bug — both needed:

### 1. Create-session POST (CORS) — `config.js`
`config.js` baked `infernoHost` from `site.inferno_host`, so the dev/preview UI POSTed cross-origin to a different host → blocked by CORS. Now uses `window.location.origin` (same-origin; the site, API and session pages always share a host via the `/suites` proxy).

### 2. Post-create redirect — `nginx.conf`
After creating the session, inferno_core 302s to `URI.join(ENV['INFERNO_HOST'], base_path)/<suite>/<id>` — an absolute URL with the baked host, sending the user to the wrong environment. A scoped `proxy_redirect` rewrites absolute `/suites` redirects to **relative** so the browser resolves them against its current origin:
```nginx
proxy_redirect ~^https?://[^/]+(/suites/.*)$ $1;
```

Together these make the full **create → redirect** flow correct on dev, prod, and every preview, with no per-environment host config. Supersedes #116 (folded in here).

### Verify
On this PR's preview I'll create a session in-browser and confirm it stays on the preview host through the redirect (and `curl -D -` the redirect path to show the `Location` is now relative).