### PR TITLE
fix(nginx): make inferno_core /suites redirects relative (host-agnostic)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -90,6 +90,14 @@ http {
     # Proxy to individual services
 
     location /suites {
+      # inferno_core builds absolute redirects from INFERNO_HOST, e.g. creating a session
+      # 302s /suites/test_sessions/<id> -> <INFERNO_HOST>/suites/<suite>/<id>. INFERNO_HOST
+      # is baked at build time, so under build-once (one image for staging + prod, and the
+      # dev-flavoured image for previews) that host is wrong for the environment actually
+      # serving the page and the user gets bounced to the wrong host. Rewrite absolute
+      # /suites redirects to relative so the browser resolves them against its current
+      # origin (scoped to /suites so external redirects, e.g. OAuth, are left untouched).
+      proxy_redirect ~^https?://[^/]+(/suites/.*)$ $1;
       proxy_pass http://inferno:4567;
     }
 


### PR DESCRIPTION
## Problem
Creating a session on a preview (or staging) **redirects the user to the wrong host**:
```
GET https://pr-115.preview…/suites/test_sessions/<id>
→ 302 Location: https://development.inferno.sparked-fhir.com/suites/au_core_v200/<id>
```
So the session is created on the preview but the user lands on dev, where it doesn't exist.

## Cause
inferno_core builds absolute redirects: `base_url = URI.join(ENV['INFERNO_HOST'], base_path)`, then `redirect_to "#{base_url}/#{suite}/#{id}"`. `INFERNO_HOST` is baked from `.env`/`.env.development` at build time, so under **build-once** it can't be right for every host. (This is the second half of the CORS issue — #115 fixed the create-session POST via `window.location.origin`; this fixes the redirect that follows.)

## Fix
Scoped `proxy_redirect` in the `/suites` location rewrites absolute `/suites` redirects to **relative**, so the browser resolves them against its current origin — host-agnostic across dev, prod, and previews, no per-env config:
```nginx
proxy_redirect ~^https?://[^/]+(/suites/.*)$ $1;
```
Scoped to `/suites` so external redirects (e.g. OAuth) are left untouched. (The live nginx config is the baked root `nginx.conf`; the chart's `nginx-configmap.yaml` is unused — separate cleanup.)

## Verify
On a preview off this branch I'll `curl -D -` the post-create `/suites/test_sessions/<id>` path and confirm the `Location` is now **relative** and resolves to the preview's own host.