### PR TITLE
fix(validator): never co-locate two validators on one node (anti-affinity)

### DIFF
--- a/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
@@ -33,6 +33,18 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         karpenter.sh/capacity-type: on-demand  # stable nodes: avoid spot-reclamation churn disrupting test runs
+      affinity:
+        # The validator is the heaviest pod we run (multi-GB JVM heap, ~9.5Gi resident).
+        # Never put two validators on the same node: when two warm up together their real
+        # usage can exceed the node's RAM and hard-freeze the kubelet (an OOM wedge took a
+        # node down on 2026-06-23 when two preview validators co-located on one m6a.xlarge).
+        # One validator per node, cluster-wide (dev/prod/each preview namespace).
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: validator-api
+            topologyKey: kubernetes.io/hostname
       volumes:
       - name: validator-presets
         configMap:


### PR DESCRIPTION
## Why
On 2026-06-23 two **preview** `validator-api` pods (pr-110 + pr-115) were scheduled onto the same `m6a.xlarge` (14.3Gi allocatable). The validator is the heaviest pod we run (multi-GB JVM heap, ~9.5Gi resident), and the preview override requested only 4Gi while actually using ~7-8Gi. Two warming together exhausted the node's RAM and **hard-froze the OS** — kubelet *and* SSM agent went silent simultaneously (the EC2 instance stayed `running` with passing status checks, so nothing auto-recovered it). That node hosted `argocd-application-controller-0`, so ArgoCD stopped reconciling cluster-wide until the pod was force-rescheduled.

## Change
Add **required** `podAntiAffinity` on `app=validator-api` with `topologyKey: kubernetes.io/hostname` — no two validators ever share a node (dev, prod, and every preview namespace count toward the same label). Combined with the preview resource-request fix (sparked-argo), this makes one-validator-per-node a hard guarantee, so a single node can never be over-committed by stacked validators.

## Verify
`helm template` + `helm lint` pass; the rendered `validator-api` Deployment carries the anti-affinity rule. Karpenter provisions a node per validator as needed (validators already dominate a node's RAM, so this matches reality).