### PR TITLE
[EXPERIMENT — DO NOT MERGE] revert #114 to A/B test au_core boot-warming

### DIFF
--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -10,10 +10,3 @@ data:
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}
   RAILS_ENV: {{ default "production" .Values.inferno.railsEnv | quote }}
   PERFORMANCE_MONITORING_ENABLED: {{ .Values.inferno.performanceMonitoring | default false | quote }}
-  # Disable inferno_core's boot-time per-suite validator-session warming
-  # (config/boot/validator.rb). It validates a throwaway Patient for every suite; au_core_v100
-  # and au_core_v200 get handed the same validator sessionId, which collides on the
-  # validator_sessions table's unique validator_session_id index (save only handles the
-  # test_suite/options/validator conflict) and the job then retries forever. The dedicated
-  # validator-warmer CronJob keeps the real session hot through the actual API path instead.
-  INITIALIZE_VALIDATOR_SESSIONS: {{ .Values.inferno.initializeValidatorSessions | default false | quote }}


### PR DESCRIPTION
**Experimental — not for merge.** Reverts #114 (re-enables `INITIALIZE_VALIDATOR_SESSIONS` boot-warming) so its preview can be A/B'd against pr-110 (warming OFF) to measure the real au_core warming benefit.

Hypothesis under test: does boot-warming actually warm the **au_core** engine? The warmer validates a base `FHIR::Patient` (not an au_core profile) and au_core_v100/v200 collide on one session id — so warming may save a cold engine build, or may have done nothing for au_core. Hard numbers to follow.

Will be closed after measurement.