### PR TITLE
fix(warmer): auto-expire finished warmer jobs (ttlSecondsAfterFinished)

### DIFF
--- a/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
+++ b/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
@@ -33,6 +33,12 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      # Auto-delete each finished Job (success OR failure) and its pods after 1h, so stale
+      # jobs don't linger. Without this, failedJobsHistoryLimit keeps the last failures
+      # indefinitely and kube_state_metrics' kube_job_failed keeps the Grafana "Job Failed"
+      # alert firing long after the warmer has recovered. 1h leaves a window to notice a
+      # real failure; a recurring failure keeps the alert firing via fresh jobs.
+      ttlSecondsAfterFinished: 3600
       activeDeadlineSeconds: {{ add (.Values.warmer.pollTimeout | int) 120 }}
       template:
         metadata:


### PR DESCRIPTION
## Problem
Stale warmer Jobs linger and keep firing Grafana `Job Failed / BackoffLimitExceeded` alerts. A 16h-old `validator-warmer-29703240` failure in **dev + prod** was still alerting even though every warmer since has completed in ~10s. The CronJob keeps `failedJobsHistoryLimit: 3` failures indefinitely (they're only evicted by 3 *newer* failures, which never come once the warmer recovers), and `kube_job_failed` fires the whole time.

## Fix
Add `ttlSecondsAfterFinished: 3600` to the warmer CronJob's `jobTemplate.spec`. The TTL-after-finished controller then deletes each Job (and its pods) ~1h after it finishes — **success or failure** — so stale jobs clear themselves. A genuine failure still alerts for up to ~1h (and a *recurring* failure keeps firing via fresh jobs), but a one-off failure auto-resolves once the warmer recovers.

Verified with `helm template`/`lint`. (Existing failed jobs predate this and still need a one-time manual delete.)