### PR TITLE
Promote prod → d60446c

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f
   usesWrapper: true
   validatorImageUri: markiantorno/validator-wrapper:1.0.68
 
@@ -22,7 +22,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:06841a7b2713444b5951f29fead71d3064db88fc-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `06841a7` → `d60446c` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`06841a7`)
- docs: add dev-workflow guide + refresh CI/CD docs (#111)
- fix(redis): set fsGroup so RDB persistence works on fresh PVCs (#112)
- fix(deps): pin connection_pool to 2.x for Sidekiq 7.2.4 compatibility (#113)
- fix(validator): disable inferno_core boot-time validator-session warming (#114)
- fix(web): make session create + redirect host-agnostic (CORS + redirect) (#115)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/06841a7b2713444b5951f29fead71d3064db88fc...d60446c4c41a924fbfa0c445dd6d66ac913cd54f

- app:   `ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f-nginx`
