### PR TITLE
fix(validator): pin prod validator-wrapper to 1.0.78 (core 6.9.7)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -79,7 +79,7 @@ The infrastructure is divided into two main components:
 | `snapshot_identifier` | Optional RDS snapshot for restore | `null` |
 | `imageUrl` | Application image URL | Required |
 | `platformImageUri` | Platform image URI | Required |
-| `validatorImageUri` | Validator image URI | `markiantorno/validator-wrapper:1.0.68` |
+| `validatorImageUri` | Validator image URI | `markiantorno/validator-wrapper:1.0.78` |
 | `usesWrapper` | Whether app is an Inferno wrapper | Required |
 
 ### Terraform Outputs

--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -13,7 +13,13 @@ redirectIngress:
 inferno:
   imageUrl: ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f
   usesWrapper: true
-  validatorImageUri: markiantorno/validator-wrapper:1.0.68
+  # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
+  # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
+  # reload that 1.0.68 lacked (1.0.68 rebuilt the whole ValidationService — wiping the
+  # session cache — on ANY request seeing free heap under the ~238MB default threshold,
+  # with no cooldown), and ships a newer org.hl7.fhir.core. Prod stays pinned (never
+  # :latest) so promotions are explicit; bump this tag to adopt a newer soaked version.
+  validatorImageUri: markiantorno/validator-wrapper:1.0.78
 
 autoscaling:
   enabled: true

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -19,7 +19,7 @@ inferno:
   imageUrl: "ghcr.io/hl7au/au-fhir-inferno:overridden-per-environment"
   terminologyServer: "https://tx.dev.hl7.org.au/fhir"
   externalValidatorUrl: null  # This can be overridden during chart deployment
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.68"
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.78"
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false


### PR DESCRIPTION
## What

Bump the **prod** validator-wrapper image `1.0.68 → 1.0.78` (and the base-chart default). Dev is unchanged (tracks `:latest`, currently 1.0.78).

## Why

Prod AU Core **v1.0.0** runs intermittently failed with:

```
java.lang.Error: Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient|1.0.0
    at org.hl7.fhir.validation.ValidationEngine.asSdList(ValidationEngine.java:629)
```

Root cause is a **context-clone bug in `org.hl7.fhir.core` 6.6.3** (which wrapper 1.0.68 pins). `CanonicalResourceManager.copy()` copied `list`/`map` but **not `listForUrl`**. Every cached/reused validator session is a *clone* of a preset base engine; with AU Core **1.0.0 and 2.0.0 co-resident** in one JVM (both presets loaded, sharing the `au-core-patient` canonical URL), a later `drop()`/reindex on the clone removed the `…|1.0.0` key and couldn't restore it (empty `listForUrl`), so `get(url,"1.0.0")` returned `null`. 2.0.0 (loaded first) held the winning bare-url/majmin keys, so **v2.0.0 always resolved; only v1.0.0 hit the hole** — matching the observed "fresh v1 works, reused v1 intermittently fails".

Verified live on prod: the package is present and correct on the PVC, a *fresh* v1.0.0 session validates fine, and the failure only occurs on a **reused/cached** session — consistent with the clone path.

**core 6.9.7 fixes it** — `copy()` now deep-copies `listForUrl` (commit `3a08028b3b`, [hapifhir/org.hl7.fhir.core#2327](https://github.com/hapifhir/org.hl7.fhir.core/pull/2327) *"fix issue cloning contexts"*). Wrapper **1.0.78 pins core 6.9.7** and additionally adds a `ReentrantLock` + 5-min cooldown around the heap-pressure engine reload that 1.0.68 fired unconditionally on every low-free-heap request. Expected outcome: **eliminates** the desync, not just reduces it.

## Deploy note

`inferno-prod` (ArgoCD) tracks `master` with **autoSync + selfHeal**, so **merging this PR deploys to prod** on next sync (a live `kubectl set image` would be self-healed away — git is the only durable path). Dev has soaked 1.0.78 for weeks.

## Immediate mitigation already applied

The prod validator was rolled-restarted to drop the poisoned cached session, so v1.0.0 runs work now; this PR is the durable fix.

## Follow-up (separate PR)

Extending the validator warmer to also cover AU Core v1/v2 (direct-wrapper probe + a lenient conformance run) and tightening its cadence to 5 min — health-check/warm only, tracked separately.