### PR TITLE
feat(warmer): cover AU Core v1/v2, add conformance job, 5-min cadence

### DIFF
--- a/VALIDATOR_OPTIMIZATION.md
+++ b/VALIDATOR_OPTIMIZATION.md
@@ -252,9 +252,33 @@ CPU peaked **~2.0 / 3 cores** (no throttling), memory **flat ~9.5Gi / 12Gi** (no
 
 **Two cold costs, not one (prod load test, fresh pod).** A no-prewarm prod run measured a cold *session* build of ~33s (small) / ~53s (large), then a single warm validation of ~3–4s — but `conc=10` of a large bundle took ~160–180s with CPU only ~1.7/3 cores. It's not CPU-bound: prod's terminology-cache PVC was fresh, so concurrent validations hit tx.dev for uncached codes and serialise. Dev did `conc=10` in ~13s only because its tx cache was thoroughly warm. So warming has **two** parts — the per-session engine build (held by the never-expire cache) and the **per-code terminology cache** (only warmed by actually validating representative bundles) — and the tx cache is what makes *concurrency* fast.
 
-**Warmer / synthetic health check** (`templates/validator-warmer.cronjob.yaml`, `warmer.*` values). A CronJob runs one `au_ps_bundle` validation through Inferno's real path every ~30 min (the tx cache persists on the PVC across restarts, so the only recurring need is re-warming the in-memory session after a restart). It warms **both** the session and the tx cache, and because it goes through Inferno it warms the *same* session id real users hit (a self-prewarm on the validator would use a throwaway id and not help Inferno's path, nor can `baseEngine` clone cheaply). It self-heals after a validator restart and doubles as an end-to-end synthetic check (the Job fails on an unreachable/errored/timed-out chain). Before a high-load event, tighten `warmer.schedule` and/or validate the full example set so the tx cache is fully warm.
+**Warmer / synthetic health check** (`templates/validator-warmer.cronjob.yaml`, `warmer.*` values, `files/warmer.py`). Each entry in `warmer.jobs` becomes its own CronJob so cadences can differ; `warmer.py` runs the checks named in that job's `CHECKS`:
+
+| Check | What it does | Warms Inferno's session id? |
+|---|---|---|
+| `au_ps` | one `au_ps_bundle` validation through Inferno's real path | ✓ (AU PS session) |
+| `aucore_wrapper` | direct validator `/validate` for AU Core 1.0.0 **and** 2.0.0, asserting `au-core-patient\|<version>` resolves; mints a session then re-sends its id to exercise the **reuse/clone** path | ✗ (wrapper mints a throwaway id) |
+| `aucore_conformance` | real `au_core_v100`/`au_core_v200` runs through Inferno against `warmer.aucoreServerUrl` | ✓ (AU Core session) + tx cache |
+
+Two jobs ship by default: **`fast`** (`au_ps,aucore_wrapper`, every 5 min — lightweight, no external dependency) and **`conformance`** (`aucore_conformance`, every 6 h — the only path that warms the exact AU Core session id real users hit, but it depends on an external server so it is **lenient**: only an unreachable/errored/timed-out *Inferno* chain fails it; validation/data/external-server results never do). Set `enabled: false` on the conformance job to drop the external dependency.
+
+Because it goes through Inferno, `au_ps`/`aucore_conformance` warm the *same* session id real users hit (a self-prewarm on the validator would use a throwaway id). `aucore_wrapper` cannot (the wrapper mints its own id and doesn't persist to Inferno's `validator_sessions`) — its value is cheap warming of both AU Core base engines + a **regression probe** for the resolution bug below: a broken resolve returns HTTP 500 (the historical failure mode), failing the Job. Note the AU Core suites have **no** standalone paste-a-resource validation test, so there is no way to warm their exact session id without a live server — hence `aucore_conformance`.
+
+**Cadence:** sessions never time-expire (`SESSION_CACHE_DURATION=-1`), so the interval is not fighting a TTL — it only bounds the post-restart cold window and how fast a broken validator is detected. 5 min keeps both small; before a high-load event, tighten `warmer.jobs[].schedule` and/or validate the full example set so the tx cache is fully warm.
 
 **Useful wrapper ops endpoints:** `GET /validator/presets` (loaded base engines), `/validator/engines` (cached sessions), `/txStatus`, `/packStatus`, `/validator/version`.
+
+---
+
+### 9. 2026-07: `Unable to resolve profile au-core-patient|1.0.0` — a context-clone bug, fixed by the wrapper bump
+
+Prod AU Core **v1.0.0** runs intermittently 500'd with `java.lang.Error: Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient|1.0.0` (from `ValidationEngine.asSdList`), always on a **reused/cached** session (`Cached session exists … Cache size = 2`), never on v2.0.0, never on a fresh session.
+
+**Root cause — `org.hl7.fhir.core` 6.6.3 (pinned by wrapper 1.0.68).** `CanonicalResourceManager.copy()` copied `list`/`map` but **not `listForUrl`**. Every cached/reused validator session is a *clone* of a preset base engine (`SimpleWorkerContext(other)` → `BaseWorkerContext.copy()` → `structures.copy()`). With AU Core 1.0.0 **and** 2.0.0 co-resident in one JVM (both presets loaded, sharing the `au-core-patient` canonical url), a later `drop()`/reindex on the clone removed the `…|1.0.0` key and could not repair it because the clone's `listForUrl` was empty. 2.0.0 (loaded first) owned the winning bare-url and majmin keys, so **v2.0.0 always resolved via its own intact keys; only the losing version (1.0.0) depended on the fragile per-version key** the shallow copy dropped. `get(url, version)` is strict — it tries `url|version` then `url|majmin`, with **no** bare-url fallback — so once the key was gone, resolution returned null for the life of that engine. This is why fresh v1 always worked and reused v1 flaked.
+
+**Fix — bump the wrapper to 1.0.78 (core 6.9.7).** core 6.9.7's `copy()` now deep-copies `listForUrl` (commit `3a08028b3b`, [hapifhir/org.hl7.fhir.core#2327](https://github.com/hapifhir/org.hl7.fhir.core/pull/2327) *"fix issue cloning contexts"*), which repairs `drop()`/reindex on clones and eliminates the desync. Wrapper 1.0.78 also adds a `ReentrantLock` + 5-min cooldown around the heap-pressure engine reload that 1.0.68 fired **unconditionally, per request**, whenever `Runtime.freeMemory() < VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD` (~238 MB default) — a rebuild that wiped the whole session cache mid-traffic and multiplied the number of clones (opportunities to hit the broken `copy()`). Prod is pinned to `1.0.78`; dev tracks `:latest` (already 1.0.78). The `aucore_wrapper` warmer check (§8) is the standing regression probe.
+
+**Immediate mitigation** when a poisoned session is live: `kubectl rollout restart deploy/validator-api -n <ns>` drops the in-memory cache; the next run rebuilds a clean session.
 
 ## Managing PVCs
 

--- a/infra/helm/inferno/files/warmer.py
+++ b/infra/helm/inferno/files/warmer.py
@@ -2,81 +2,227 @@
 """
 Validator warmer / synthetic health check.
 
-Runs one au_ps_bundle validation through Inferno's real API path
-(Inferno -> worker -> validator -> tx server). Serves two purposes:
+Runs one or more checks (selected via the CHECKS env, comma-separated) to keep the
+validator warm and to act as an end-to-end synthetic health check. Every check both
+WARMS (so real users don't pay a cold start after a validator restart) and PROBES
+(exits non-zero on an infrastructure failure so the CronJob surfaces it). Benign,
+data-dependent validation warnings/errors never fail the check.
 
-  1. WARM-UP: keeps the validator's session engine and terminology cache hot, and
-     re-warms them after a validator pod restart. Because it goes through Inferno it
-     warms the *same* validator session id real users hit (a self-prewarm on the
-     validator would use a throwaway id and not help Inferno's path).
-  2. SYNTHETIC HEALTH CHECK: exercises the full validation chain end to end on a
-     schedule. Exits non-zero on an infrastructure failure (unreachable, run errored,
-     timeout) so the CronJob surfaces it; benign validation warnings/errors in the
-     bundle do NOT fail the check (those are data-dependent and expected).
+Checks
+------
+  au_ps              One au_ps_bundle validation through Inferno's real API path
+                     (Inferno -> worker -> validator -> tx). Warms the *same* validator
+                     session id real AU PS users hit (Inferno keys a session per
+                     (test_suite_id, suite_options, validator_name), so going through
+                     Inferno is the only way to warm that exact id).
 
-Stdlib only. Config via env: INFERNO_URL, TEST_SUITE_ID, PROFILE, BUNDLE_PATH, POLL_TIMEOUT.
+  aucore_wrapper     Direct validator-wrapper /validate for AU Core 1.0.0 and 2.0.0,
+                     asserting au-core-patient|<version> resolves. Mints a session then
+                     re-sends its id to exercise the reuse/clone path (the path where
+                     the historical core 6.6.3 "Unable to resolve profile ...|1.0.0"
+                     desync lived). Cheap, no external server needed; warms both base
+                     engines + their terminology cache and fails loudly if resolution
+                     ever breaks. NOTE: the wrapper mints its own session id and does
+                     not persist to Inferno's validator_sessions table, so this warms
+                     the validator's engine/tx caches but not Inferno's stored session
+                     id -- use aucore_conformance for the same-session, end-to-end warm.
+
+  aucore_conformance A real au_core_v100 / au_core_v200 run through Inferno against a
+                     live AU Core server (AUCORE_SERVER_URL). This is the only path that
+                     hits the exact (au_core_vXXX, [], :default) session id real users
+                     get, and warms the tx cache with real AU Core codes. It depends on
+                     an external server, so it is LENIENT: it fails only when the Inferno
+                     chain itself is unreachable/errors/times out, never on validation,
+                     data, or external-server results.
+
+Stdlib only. Config via env:
+  INFERNO_URL, VALIDATOR_URL, TX_SERVER, CHECKS, POLL_TIMEOUT,
+  TEST_SUITE_ID, PROFILE, BUNDLE_PATH        (au_ps)
+  AUCORE_SERVER_URL                          (aucore_conformance)
 """
 import json, os, sys, time, urllib.request, urllib.error
 
-URL = os.environ.get("INFERNO_URL", "http://inferno:4567").rstrip("/")
-SUITE = os.environ.get("TEST_SUITE_ID", "suite_100preview")
-PROFILE = os.environ.get("PROFILE", "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle")
-BUNDLE_PATH = os.environ.get("BUNDLE_PATH", "/warmer/warmer-bundle.json")
+INFERNO_URL = os.environ.get("INFERNO_URL", "http://inferno:4567").rstrip("/")
+VALIDATOR_URL = os.environ.get("VALIDATOR_URL", "http://validator-api:3500").rstrip("/")
+TX_SERVER = os.environ.get("TX_SERVER", "https://tx.dev.hl7.org.au/fhir")
+CHECKS = [c.strip() for c in os.environ.get("CHECKS", "au_ps,aucore_wrapper").split(",") if c.strip()]
 POLL_TIMEOUT = int(os.environ.get("POLL_TIMEOUT", "300"))
-API = f"{URL}/suites/api"
+
+# au_ps check config
+AU_PS_SUITE = os.environ.get("TEST_SUITE_ID", "suite_100preview")
+AU_PS_PROFILE = os.environ.get("PROFILE", "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle")
+BUNDLE_PATH = os.environ.get("BUNDLE_PATH", "/warmer/warmer-bundle.json")
+
+# aucore_conformance check config
+AUCORE_SERVER_URL = os.environ.get("AUCORE_SERVER_URL", "https://fhir.hl7.org.au/aucore/fhir/DEFAULT")
+
+# AU Core versions to probe / warm. baseEngine keys must match the validator presets
+# (validator-presets-configmap.yaml); igs versions must match the suite fhir_resource_validator.
+AU_CORE_VERSIONS = [
+    {"version": "1.0.0", "ig": "hl7.fhir.au.core#1.0.0", "base_engine": "AU_CORE_V1_0_0", "suite": "au_core_v100"},
+    {"version": "2.0.0", "ig": "hl7.fhir.au.core#2.0.0", "base_engine": "AU_CORE_V2_0_0", "suite": "au_core_v200"},
+]
+AU_CORE_PATIENT = "http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
 
 
-def http(method, path, body=None, timeout=60):
-    req = urllib.request.Request(API + path, method=method,
-                                 data=(body.encode() if body else None),
-                                 headers={"Content-Type": "application/json", "Accept": "application/json"})
+def _http(url, body=None, timeout=60):
+    req = urllib.request.Request(
+        url, method=("POST" if body is not None else "GET"),
+        data=(body.encode() if body else None),
+        headers={"Content-Type": "application/json", "Accept": "application/json"})
     with urllib.request.urlopen(req, timeout=timeout) as r:
-        return json.loads(r.read().decode() or "{}")
+        return r.getcode(), json.loads(r.read().decode() or "{}")
 
 
-def fail(msg):
-    print(f"warmer UNHEALTHY: {msg}", flush=True)
-    sys.exit(1)
+def inferno(method, path, body=None, timeout=60):
+    return _http(f"{INFERNO_URL}/suites/api{path}", body if method == "POST" else None, timeout)[1]
 
 
-def main():
-    t0 = time.time()
+class CheckFailure(Exception):
+    """An infrastructure failure that should fail the CronJob (non-zero exit)."""
+
+
+# --------------------------------------------------------------------------- au_ps
+
+def check_au_ps():
     bundle = open(BUNDLE_PATH).read()
     try:
-        session = http("POST", f"/test_sessions?test_suite_id={SUITE}",
-                       json.dumps({"preset_id": None, "suite_options": []}))["id"]
-        run = http("POST", "/test_runs", json.dumps({
-            "test_session_id": session, "test_suite_id": SUITE, "inputs": [
+        session = inferno("POST", f"/test_sessions?test_suite_id={AU_PS_SUITE}",
+                          json.dumps({"preset_id": None, "suite_options": []}))["id"]
+        run = inferno("POST", "/test_runs", json.dumps({
+            "test_session_id": session, "test_suite_id": AU_PS_SUITE, "inputs": [
                 {"name": "validate_against", "value": json.dumps(["au_ps_bundle"]), "type": "text"},
                 {"name": "bundle_resource", "value": bundle, "type": "text"},
-                {"name": "profile", "value": PROFILE, "type": "text"},
+                {"name": "profile", "value": AU_PS_PROFILE, "type": "text"},
             ]}))["id"]
     except (urllib.error.URLError, KeyError, ValueError) as e:
-        fail(f"could not start validation: {e}")
+        raise CheckFailure(f"au_ps: could not start validation: {e}")
 
+    status = _poll_run(run, f"au_ps[{AU_PS_SUITE}]")
+    counts = _result_counts(run)
+    # "error" results indicate the run could not execute (infra), not data validation failures.
+    if counts.get("error", 0):
+        raise CheckFailure(f"au_ps: {counts['error']} test(s) errored (infrastructure)")
+    return f"au_ps[{AU_PS_SUITE}] status={status} results={counts}"
+
+
+# ------------------------------------------------------------------- aucore_wrapper
+
+def _aucore_patient(version):
+    return json.dumps({
+        "resourceType": "Patient", "id": "warmer",
+        "meta": {"profile": [f"{AU_CORE_PATIENT}|{version}"]},
+        "name": [{"family": "Warmer", "given": ["Validator"]}], "gender": "male",
+    })
+
+
+def _wrapper_validate(v, session_id=None):
+    profile = f"{AU_CORE_PATIENT}|{v['version']}"
+    ctx = {
+        "sv": "4.0.1", "igs": [v["ig"]], "extensions": ["any"],
+        "disableDefaultResourceFetcher": False, "txServer": TX_SERVER,
+        "noEcosystem": True, "baseEngine": v["base_engine"], "profiles": [profile],
+    }
+    body = {"cliContext": ctx,
+            "filesToValidate": [{"fileName": "patient.json",
+                                 "fileContent": _aucore_patient(v["version"]), "fileType": "json"}]}
+    if session_id:
+        body["sessionId"] = session_id
+    try:
+        code, resp = _http(f"{VALIDATOR_URL}/validate", json.dumps(body), timeout=POLL_TIMEOUT)
+    except urllib.error.HTTPError as e:
+        # A 500 here is exactly the historical failure mode (asSdList throwing an
+        # unhandled java.lang.Error). Surface the body.
+        raise CheckFailure(f"aucore_wrapper[{v['version']}]: HTTP {e.code}: {e.read().decode()[:300]}")
+    except urllib.error.URLError as e:
+        raise CheckFailure(f"aucore_wrapper[{v['version']}]: validator unreachable: {e}")
+    issues = (resp.get("outcomes") or [{}])[0].get("issues", [])
+    unresolved = [i for i in issues if "resolve profile" in i.get("message", "").lower()
+                  or i.get("message", "").startswith("Unable to resolve")]
+    if unresolved:
+        raise CheckFailure(f"aucore_wrapper[{v['version']}]: profile did not resolve: "
+                           f"{unresolved[0].get('message')}")
+    return resp.get("sessionId"), len(issues)
+
+
+def check_aucore_wrapper():
+    out = []
+    for v in AU_CORE_VERSIONS:
+        # 1) mint a session (fresh build), 2) re-send its id to exercise the reuse/clone path.
+        sid, n1 = _wrapper_validate(v)
+        _, n2 = _wrapper_validate(v, session_id=sid) if sid else (None, n1)
+        out.append(f"{v['version']}(fresh={n1},reuse={n2})")
+    return "aucore_wrapper resolved: " + ", ".join(out)
+
+
+# --------------------------------------------------------------- aucore_conformance
+
+def check_aucore_conformance():
+    # LENIENT: warms the real Inferno session id + tx cache against a live server. Only an
+    # unreachable/timed-out Inferno chain fails the check; validation/data/external-server
+    # results (including a fully-down reference server) are expected and do not fail.
+    out = []
+    for v in AU_CORE_VERSIONS:
+        suite = v["suite"]
+        try:
+            session = inferno("POST", f"/test_sessions?test_suite_id={suite}",
+                              json.dumps({"preset_id": None, "suite_options": []}))["id"]
+            run = inferno("POST", "/test_runs", json.dumps({
+                "test_session_id": session, "test_suite_id": suite,
+                "inputs": [{"name": "url", "value": AUCORE_SERVER_URL, "type": "text"}]}))["id"]
+        except (urllib.error.URLError, KeyError, ValueError) as e:
+            raise CheckFailure(f"aucore_conformance[{suite}]: could not start run: {e}")
+        status = _poll_run(run, f"aucore_conformance[{suite}]")
+        out.append(f"{suite} status={status} results={_result_counts(run)}")
+    return "aucore_conformance: " + " | ".join(out)
+
+
+# --------------------------------------------------------------------------- helpers
+
+def _poll_run(run, label):
     deadline = time.time() + POLL_TIMEOUT
     status = None
     while time.time() < deadline:
         try:
-            status = http("GET", f"/test_runs/{run}").get("status")
+            status = inferno("GET", f"/test_runs/{run}").get("status")
         except urllib.error.URLError as e:
-            fail(f"polling failed: {e}")
+            raise CheckFailure(f"{label}: polling failed: {e}")
         if status in ("done", "cancelled"):
-            break
+            return status
         time.sleep(2)
-    else:
-        fail(f"validation did not finish within {POLL_TIMEOUT}s (last status={status})")
+    raise CheckFailure(f"{label}: run did not finish within {POLL_TIMEOUT}s (last status={status})")
 
-    elapsed = time.time() - t0
-    results = http("GET", f"/test_runs/{run}/results")
+
+def _result_counts(run):
     counts = {}
-    for r in results:
+    for r in inferno("GET", f"/test_runs/{run}/results"):
         counts[r.get("result", "?")] = counts.get(r.get("result", "?"), 0) + 1
-    # "error" results indicate the run could not execute (infra), not data validation failures.
-    errored = counts.get("error", 0)
-    print(f"warmer OK: suite={SUITE} status={status} elapsed={elapsed:.1f}s results={dict(sorted(counts.items()))}", flush=True)
-    if errored:
-        fail(f"{errored} test(s) errored (infrastructure)")
+    return dict(sorted(counts.items()))
+
+
+CHECK_FUNCS = {
+    "au_ps": check_au_ps,
+    "aucore_wrapper": check_aucore_wrapper,
+    "aucore_conformance": check_aucore_conformance,
+}
+
+
+def main():
+    t0 = time.time()
+    unknown = [c for c in CHECKS if c not in CHECK_FUNCS]
+    if unknown:
+        print(f"warmer UNHEALTHY: unknown check(s) {unknown}; valid: {list(CHECK_FUNCS)}", flush=True)
+        sys.exit(2)
+    failures = []
+    for name in CHECKS:
+        try:
+            print(f"warmer OK: {CHECK_FUNCS[name]()}", flush=True)
+        except CheckFailure as e:
+            print(f"warmer UNHEALTHY: {e}", flush=True)
+            failures.append(name)
+    print(f"warmer done: checks={CHECKS} failed={failures} elapsed={time.time() - t0:.1f}s", flush=True)
+    if failures:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
+++ b/infra/helm/inferno/templates/validator-warmer.cronjob.yaml
@@ -1,13 +1,22 @@
 {{- if .Values.warmer.enabled }}
-# Validator warmer / synthetic health check. Periodically runs one au_ps_bundle
-# validation through Inferno's real API path (Inferno -> worker -> validator -> tx),
-# which (1) keeps the validator's session engine + terminology cache warm and re-warms
-# them after a validator pod restart — going through Inferno warms the *same* session id
-# real users hit, which a self-prewarm on the validator can't do — and (2) acts as an
-# end-to-end synthetic check (the Job fails if the chain is unreachable/errors/times out).
-# The never-expire session cache keeps things warm between runs, so a modest cadence is
-# enough; raise warmer.schedule frequency (and run the full example set manually) to fully
-# warm the terminology cache before an event. See docs/VALIDATOR_OPTIMIZATION.md.
+# Validator warmer / synthetic health check. Runs validation checks through the real
+# stack on a schedule to (1) keep the validator's session engines + terminology cache
+# warm (and re-warm them after a validator pod restart) and (2) act as an end-to-end
+# synthetic check (a Job fails if the chain is unreachable/errors/times out).
+#
+# Checks (selected per-job via CHECKS; see files/warmer.py):
+#   au_ps              au_ps_bundle validation through Inferno — warms the AU PS session.
+#   aucore_wrapper     direct validator /validate for AU Core 1.0.0 + 2.0.0, asserting
+#                      au-core-patient|<version> resolves (mint + re-send to exercise the
+#                      reuse/clone path). Cheap, no external server; warms both base
+#                      engines and fails loudly on a resolution regression.
+#   aucore_conformance real au_core_v100/v200 runs through Inferno against a live AU Core
+#                      server — warms the exact session id real users hit + the tx cache;
+#                      LENIENT (only an unreachable Inferno chain fails it).
+#
+# Jobs are defined in .Values.warmer.jobs (one CronJob each) so cadences can differ: a
+# frequent lightweight job (au_ps + aucore_wrapper) and a gentle conformance job that
+# depends on an external server. See VALIDATOR_OPTIMIZATION.md.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,14 +27,17 @@ data:
 {{ .Files.Get "files/warmer.py" | indent 4 }}
   warmer-bundle.json: |
 {{ .Files.Get "files/warmer-bundle.json" | indent 4 }}
+{{- $root := . }}
+{{- range .Values.warmer.jobs }}
+{{- if (default true .enabled) }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: validator-warmer
-  namespace: {{ .Release.Namespace }}
+  name: validator-warmer-{{ .name }}
+  namespace: {{ $root.Release.Namespace }}
 spec:
-  schedule: {{ .Values.warmer.schedule | quote }}
+  schedule: {{ .schedule | quote }}
   concurrencyPolicy: Forbid            # never overlap warmer runs
   startingDeadlineSeconds: 120
   successfulJobsHistoryLimit: 3
@@ -39,11 +51,14 @@ spec:
       # alert firing long after the warmer has recovered. 1h leaves a window to notice a
       # real failure; a recurring failure keeps the alert firing via fresh jobs.
       ttlSecondsAfterFinished: 3600
-      activeDeadlineSeconds: {{ add (.Values.warmer.pollTimeout | int) 120 }}
+      # A conformance job runs one full au_core run per version, so allow room beyond a
+      # single POLL_TIMEOUT; the lightweight jobs finish well inside it.
+      activeDeadlineSeconds: {{ add (mul ($root.Values.warmer.pollTimeout | int) (.deadlinePolls | default 1 | int)) 120 }}
       template:
         metadata:
           labels:
             app: validator-warmer
+            warmer-job: {{ .name }}
         spec:
           restartPolicy: Never
           nodeSelector:
@@ -54,19 +69,27 @@ spec:
               name: validator-warmer
           containers:
           - name: warmer
-            image: {{ .Values.warmer.image | quote }}
+            image: {{ $root.Values.warmer.image | quote }}
             command: ["python3", "/warmer/warmer.py"]
             env:
+            - name: CHECKS
+              value: {{ .checks | quote }}
             - name: INFERNO_URL
-              value: {{ .Values.warmer.infernoUrl | quote }}
+              value: {{ $root.Values.warmer.infernoUrl | quote }}
+            - name: VALIDATOR_URL
+              value: {{ $root.Values.warmer.validatorUrl | quote }}
+            - name: TX_SERVER
+              value: {{ $root.Values.warmer.txServer | default $root.Values.inferno.terminologyServer | quote }}
             - name: TEST_SUITE_ID
-              value: {{ .Values.warmer.testSuiteId | quote }}
+              value: {{ $root.Values.warmer.testSuiteId | quote }}
             - name: PROFILE
-              value: {{ .Values.warmer.profile | quote }}
+              value: {{ $root.Values.warmer.profile | quote }}
+            - name: AUCORE_SERVER_URL
+              value: {{ $root.Values.warmer.aucoreServerUrl | quote }}
             - name: BUNDLE_PATH
               value: /warmer/warmer-bundle.json
             - name: POLL_TIMEOUT
-              value: {{ .Values.warmer.pollTimeout | quote }}
+              value: {{ $root.Values.warmer.pollTimeout | quote }}
             volumeMounts:
             - name: warmer
               mountPath: /warmer
@@ -78,4 +101,6 @@ spec:
               limits:
                 memory: "128Mi"
                 cpu: "250m"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -70,21 +70,41 @@ validator:
 # See docs/VALIDATOR_OPTIMIZATION.md.
 
 # Validator warmer / synthetic health check (templates/validator-warmer.cronjob.yaml).
-# Periodically runs one au_ps_bundle validation through Inferno's real path, which keeps
-# the validator session + terminology cache warm (and re-warms after a pod restart, since
-# going through Inferno warms the same session id real users hit), and doubles as an
-# end-to-end synthetic check. The terminology cache persists on the PVC across restarts,
-# so the only recurring need is re-warming the in-memory session after an (infrequent)
-# restart — 30 min is ample. Tighten before an event to fully warm the tx cache for the
-# codes participants will use.
+# Runs validation checks through the real stack to keep the validator's session engines +
+# terminology cache warm (and re-warm them after a pod restart) and to act as an
+# end-to-end synthetic check. See files/warmer.py for the check implementations.
+#
+# Cadence note: validator sessions never time-expire (SESSION_CACHE_DURATION=-1), so the
+# warmer is not fighting a TTL — its interval only bounds how long a post-restart cold
+# window lasts and how quickly a broken validator is detected. 5 min keeps both small.
+#
+# Jobs: each entry becomes its own CronJob so cadences can differ.
+#   fast        (5 min)  au_ps + aucore_wrapper — lightweight, no external dependency.
+#   conformance (6 h)    real au_core_v100/v200 runs vs an external AU Core server; warms
+#                        the exact session id real users hit + the tx cache. Lenient: only
+#                        an unreachable Inferno chain fails it (external-server flakiness
+#                        is expected). Set enabled:false to drop the external dependency.
 warmer:
   enabled: true
-  schedule: "*/30 * * * *"
   image: "python:3.12-slim"
-  infernoUrl: "http://inferno:4567"   # in-cluster; /suites proxies here
+  infernoUrl: "http://inferno:4567"          # in-cluster; /suites proxies here
+  validatorUrl: "http://validator-api:3500"  # in-cluster validator service (direct probe)
+  txServer: ""                               # empty -> inferno.terminologyServer
+  # au_ps check inputs
   testSuiteId: "suite_100preview"
   profile: "http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle"
+  # aucore_conformance server (a live AU Core endpoint to run the conformance suites against)
+  aucoreServerUrl: "https://fhir.hl7.org.au/aucore/fhir/DEFAULT"
   pollTimeout: 300
+  jobs:
+    - name: fast
+      schedule: "*/5 * * * *"
+      checks: "au_ps,aucore_wrapper"
+    - name: conformance
+      schedule: "17 */6 * * *"
+      checks: "aucore_conformance"
+      deadlinePolls: 2   # two suites, each may take a full poll window
+      enabled: true
 
 postgresql:
   enabled: false # enable if not using rds from aws-impl


### PR DESCRIPTION
## What

Extends the validator warmer from a single 30-min AU PS check into per-cadence CronJobs that also warm and health-check **AU Core v1.0.0 and v2.0.0**.

`files/warmer.py` now runs one or more named checks (`CHECKS` env):

| Check | What | Warms Inferno's session id? |
|---|---|---|
| `au_ps` | AU PS bundle validation through Inferno (unchanged) | ✓ |
| `aucore_wrapper` | direct validator `/validate` for AU Core 1.0.0 **and** 2.0.0, asserting `au-core-patient\|<version>` resolves; mints a session then re-sends its id to exercise the reuse/clone path | ✗ (throwaway id) |
| `aucore_conformance` | real `au_core_v100`/`au_core_v200` runs through Inferno against `warmer.aucoreServerUrl` | ✓ + tx cache |

Two CronJobs ship (template ranges over `warmer.jobs`):
- **`validator-warmer-fast`** — `au_ps,aucore_wrapper`, every **5 min**. Lightweight, no external dependency.
- **`validator-warmer-conformance`** — `aucore_conformance`, every **6 h**. The only path that warms the exact AU Core session id real users hit, but depends on an external server, so it's **lenient** (only an unreachable/errored/timed-out *Inferno* chain fails it — external-server/data results never do). `enabled: true` by default; flip to drop the dependency.

The old single `validator-warmer` CronJob is replaced by the two named jobs (Argo `prune:true` removes the old one).

## Why

Follows the root-cause work behind #121. The AU Core suites are pure server-conformance suites with **no standalone paste-a-resource validation test**, so their exact validator session id can only be warmed via a real run against a server — hence the split. `aucore_wrapper` is a cheap standing **regression probe** for the `Unable to resolve profile au-core-patient|1.0.0` desync: a broken resolve returns HTTP 500 and fails the Job.

**Cadence:** validator sessions never time-expire (`SESSION_CACHE_DURATION=-1`), so the interval isn't fighting a TTL — it only bounds the post-restart cold window and detection latency. 5 min keeps both small.

## Verified

Ran all checks against the live prod validator + Inferno via port-forward:
- `au_ps` → `done`, pass 94 / skip 33
- `aucore_wrapper` → both 1.0.0 and 2.0.0 resolve (fresh + reuse)
- **negative test**: probing a nonexistent version → HTTP 500 → Job fails (the exact prod symptom is caught)
- `helm template` renders 2 CronJobs; `warmer.py` compiles.

`aucore_conformance` (external-server run) not exercised live here — validate in dev/preview after merge.

## Deploy note

`inferno-dev` and `inferno-prod` both track `master` (autoSync), so merging deploys to both. Checks are read-only validations; the conformance job hits the public AU Core server every 6 h (lenient).