### PR TITLE
fix(validator): stop AU Core v1/v2 sharing one validator session (base-class key)

### DIFF
--- a/lib/inferno_platform_template/patches.rb
+++ b/lib/inferno_platform_template/patches.rb
@@ -7,3 +7,50 @@ require 'inferno_suite_generator/test_utils/ms_checker'
 unless InfernoSuiteGenerator::MSChecker.method_defined?(:metadata)
   InfernoSuiteGenerator::MSChecker.attr_reader :metadata
 end
+
+# Fix cross-version validator-session collision (AU Core v1.0.0 <-> v2.0.0).
+#
+# inferno_core's `fhir_resource_validator` captures the declaring runnable's `id`
+# EAGERLY as the validator's `test_suite_id`
+# (dsl/fhir_resource_validation.rb: `Validator.new(name, id, ...)`). The au_core_test_kit
+# generated suites declare `fhir_resource_validator` BEFORE their `id :au_core_vXXX`
+# statement, so at capture time the suite's own id is unset. It then falls back to the
+# runnable's `@base_id`, which inferno_core copies from the base class onto every subclass
+# (dsl/runnable.rb VARIABLES_NOT_TO_COPY omits `:@base_id`), so the value is the literal
+# base-class name "Inferno::Entities::TestSuite".
+#
+# Result: the au_core_v100 and au_core_v200 :default validators BOTH carry
+# test_suite_id "Inferno::Entities::TestSuite". Validator sessions are keyed by
+# (test_suite_id, validator_name, suite_options), so both IG versions collapse onto ONE
+# validator-wrapper session/engine; whichever version built it wins, and the other 500s
+# with `Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/
+# au-core-*|<version>` (intermittent, race-dependent on run order).
+#
+# Fix: after finalize! (when suites are registered and their real ids are set), reset any
+# validator still keyed by the base-class name to its owning suite's real id, so each
+# suite gets its own session key/engine. Idempotent; only touches demonstrably-mis-keyed
+# validators. Remove once au_core_test_kit declares `id` before the validator (or
+# inferno_core adds :@base_id to VARIABLES_NOT_TO_COPY / resolves test_suite_id lazily).
+module FixValidatorSessionKeyCollision
+  BASE_SUITE_NAME = 'Inferno::Entities::TestSuite'
+
+  def finalize!(...)
+    result = super
+    Inferno::Repositories::TestSuites.new.all.each do |suite|
+      suite.fhir_validators.each_value do |validators|
+        Array(validators).each do |validator|
+          next unless validator.respond_to?(:test_suite_id)
+          next unless validator.test_suite_id == BASE_SUITE_NAME
+
+          validator.instance_variable_set(:@test_suite_id, suite.id)
+        end
+      end
+    end
+    result
+  rescue StandardError => e
+    Inferno::Application[:logger]&.warn("FixValidatorSessionKeyCollision skipped: #{e.class}: #{e.message}")
+    result
+  end
+end
+
+Inferno::Application.singleton_class.prepend(FixValidatorSessionKeyCollision)


### PR DESCRIPTION
## What
A boot-time patch (in `lib/inferno_platform_template/patches.rb`, loaded by both web and worker) that, after `Inferno::Application.finalize!`, resets any validator still keyed by the literal base-class name `Inferno::Entities::TestSuite` to its owning suite's real id.

## Why — the real root cause behind the recurring `Unable to resolve profile au-core-*|<version>` 500s

Two-link chain, **verified live** in dev:

1. **inferno_core** captures a validator's `test_suite_id` *eagerly* from the declaring runnable's `id` (`dsl/fhir_resource_validation.rb`: `Validator.new(name, id, …)`), and copies `@base_id` from the base class onto every subclass (`dsl/runnable.rb` `VARIABLES_NOT_TO_COPY` omits `:@base_id`) — so an unset id resolves to the literal `"Inferno::Entities::TestSuite"`.
2. **au_core_test_kit** generated suites declare `fhir_resource_validator` **before** `id :au_core_vXXX`, so both `au_core_v100` and `au_core_v200` `:default` validators capture `test_suite_id = "Inferno::Entities::TestSuite"`.

Validator sessions are keyed by `(test_suite_id, validator_name, suite_options)`, so **both IG versions collapse onto one validator-wrapper session/engine**. Whichever version built it wins; the other 500s on profile resolution (intermittent, race-dependent on run order). Confirmed against the Inferno DB: an actively-used `validator_sessions` row keyed `Inferno::Entities::TestSuite` served both IG versions while the correct per-suite rows sat unused. This is why the earlier wrapper-side fixes (#121/#123) couldn't resolve it — the collision is at Inferno's session-key layer.

## Verification (deterministic — no more race dependence)
Live in the dev pod, before vs after the hook:

| suite | before | after |
|---|---|---|
| `au_core_v100` | `Inferno::Entities::TestSuite` | **`au_core_v100`** |
| `au_core_v200` | `Inferno::Entities::TestSuite` | **`au_core_v200`** |
| `validations` | `validations` | `validations` (untouched) |

Recommended post-deploy E2E: on a clean instance run `au_core_v200` then `au_core_v100` (and the reverse); before the fix the 2nd 500s on profile resolution, after it both pass, because each suite now owns a distinct session/engine.

## Risk
Low: idempotent, only mutates validators whose `test_suite_id` is the base-class name (never legitimate), guarded so a failure can't break boot, and runs in both web + worker.

## Durable follow-ups (separate, this team owns both)
- **au_core_test_kit** (`hl7au/au-fhir-core-inferno`): move `id :au_core_vXXX` above the `fhir_resource_validator` block in the generated suites + fix the InfernoSuiteGenerator template. Then this patch can be removed.
- **inferno_core** (upstream): add `:@base_id` to `VARIABLES_NOT_TO_COPY` and/or resolve `test_suite_id` lazily. `config/boot/suites.rb` already special-cases this base-name leak for routing — the validator path just isn't covered.

## Deploy note
`inferno-dev`/`inferno-prod` both track `master` (autoSync); merging deploys to both. The patch takes effect on the next app boot (rollout), independent of the validator pod.