### PR TITLE
Promote prod → 2ade5a1

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d60446c4c41a924fbfa0c445dd6d66ac913cd54f-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `d60446c` → `2ade5a1` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **unchanged**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`d60446c`)
- fix(validator): never co-locate two validators on one node (#117)
- fix(warmer): auto-expire finished warmer jobs (ttlSecondsAfterFinished) (#119)
- fix(validator): pin prod validator-wrapper to 1.0.78 (core 6.9.7) (#121)
- feat(warmer): cover AU Core v1/v2, add conformance job, 5-min cadence (#122)
- fix(validator): drop base-engine presets to stop the clone desync (#123)
- fix(validator): stop AU Core v1/v2 sharing one validator session (base-class key) (#124)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/d60446c4c41a924fbfa0c445dd6d66ac913cd54f...2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf

- app:   `ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf-nginx`
