### PR TITLE
Promote prod → f608eaf

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `2ade5a1` → `f608eaf` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **unchanged**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **unchanged** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`2ade5a1`)
- feat(au-core): default the AU Core test kit to v2.0.0 (#110)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/2ade5a1dc8dd2186b59c3d8e6020f9eec8ab23bf...f608eaf403c8a681e15cdc361380d83bced54cca

- app:   `ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca-nginx`
