### PR TITLE
feat(telemetry): emit one trace per test instead of one unbounded trace per run

### DIFF
--- a/lib/inferno_platform_template/patches.rb
+++ b/lib/inferno_platform_template/patches.rb
@@ -1,6 +1,6 @@
 # Upstream bug: InfernoSuiteGenerator::MSChecker sets @metadata in initialize
 # but FHIRResourceNavigation#find_slice_via_discriminator calls metadata as a
-# method — missing attr_reader. Triggered by au_core_test_kit >= 1.4.1.
+# method, but the attr_reader is missing. Triggered by au_core_test_kit >= 1.4.1.
 # Remove once inferno_suite_generator is updated.
 require 'inferno_suite_generator/test_utils/ms_checker'
 
@@ -54,3 +54,41 @@ module FixValidatorSessionKeyCollision
 end
 
 Inferno::Application.singleton_class.prepend(FixValidatorSessionKeyCollision)
+
+# Emit one OpenTelemetry trace per test instead of one unbounded trace per run.
+#
+# inferno-core executes an entire test run inside a SINGLE Sidekiq job
+# (Inferno::Jobs::ExecuteTestRun -> TestRunner#start -> recursive #run). With the Sidekiq
+# OTel instrumentation enabled (worker.rb), that job's server span becomes the trace root,
+# so the whole run collapses into a single trace: every validator and terminology HTTP
+# request, context propagated by the Faraday / Net::HTTP instrumentation. A full run can
+# be many minutes and tens of thousands of spans, which is effectively unusable telemetry:
+# trace backends reject or truncate traces above a per-trace size limit (e.g. Tempo's
+# max_bytes_per_trace, 5MB by default), silently losing spans, and no trace UI can render
+# a multi-minute, ten-thousand-span trace anyway.
+#
+# Wrap each test in a fresh root span (empty parent context => new trace id) so every test
+# is its own bounded, queryable trace, with its downstream calls as children and a shared
+# inferno.test_run_id attribute to correlate the tests of one run. This belongs upstream in
+# inferno-core (which owns TestRunner and the one-job-per-run model); remove this patch once
+# it offers native per-test tracing. See https://github.com/inferno-framework/inferno-core
+if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+  require 'inferno/test_runner'
+
+  module PerTestTraceRoot
+    def run_test(test, scratch)
+      tracer = OpenTelemetry.tracer_provider.tracer('inferno-worker')
+      # Detach from the enclosing Sidekiq job span so the test span starts a new trace.
+      OpenTelemetry::Context.with_current(OpenTelemetry::Context.empty) do
+        tracer.in_span(
+          "inferno.test #{test.id}",
+          attributes: { 'inferno.test_run_id' => test_run.id, 'inferno.test_id' => test.id }
+        ) do
+          super
+        end
+      end
+    end
+  end
+
+  Inferno::TestRunner.prepend(PerTestTraceRoot)
+end


### PR DESCRIPTION
## Problem

A test run produces a **single unbounded trace covering the whole run**.

inferno-core executes an entire run inside one Sidekiq job (`Inferno::Jobs::ExecuteTestRun`, `TestRunner#start`, recursive `#run`). With the Sidekiq OpenTelemetry instrumentation enabled (`worker.rb`), that job's server span becomes the trace root, so every validator and terminology HTTP request the run issues, with context propagated by the Faraday / Net::HTTP instrumentation, nests under that one span.

A full run is many minutes and tens of thousands of spans, which is effectively unusable telemetry regardless of backend:

- **Spans get silently dropped.** Trace backends reject or truncate traces above a per-trace size limit (e.g. Tempo's `max_bytes_per_trace`, 5 MB by default), so the tail of a large run is lost with `reason=trace_too_large`.
- **The trace can't be read even when it is kept.** No trace UI can render a multi-minute, ten-thousand-span trace, and trace-by-id assembly of one that large tends to time out or error.

A representative run observed in the wild: roughly 15 min, about 9,950 spans across the worker, validator, and terminology server, with the root span never received because the run was still going.

## Change

Wrap each test in a fresh **root** span (empty parent context, so a new trace id), via a `TestRunner#run_test` prepend guarded by `OTEL_EXPORTER_OTLP_ENDPOINT`. Each test becomes its own bounded, queryable trace, with its downstream calls as children, tagged with a shared `inferno.test_run_id` attribute so the tests of a run can still be correlated.

The existing Faraday / Net::HTTP / Sidekiq instrumentation is untouched; the Sidekiq job trace simply becomes a single span with no HTTP children.

## Why here (and not upstream)

The proper long-term home is inferno-core itself, which owns `TestRunner` and the one-job-per-run execution model, so every deployment that enables tracing hits this. This PR carries the fix as a downstream override in `patches.rb` (the repo's established convention for framework fixes awaiting upstream) so telemetry is usable now. The comment points at inferno-core, and the patch should be removed once inferno-core offers native per-test tracing.

## Verification

Reproduced the OpenTelemetry context behaviour against the pinned gem versions (opentelemetry-api 1.10 / sdk 1.12) with an in-memory span exporter: driving two tests inside one job span yields three separate traces. The job trace is a single span with no HTTP children, and each test is its own trace containing its downstream child spans. Each test root has no parent, and the `inferno.test_run_id` attribute is set. `ruby -c` passes on the edited file.


Upstream at https://github.com/inferno-framework/inferno-core/issues/796 and https://github.com/inferno-framework/inferno-core/pull/797