### PR TITLE
Promote prod → a3d7a20 (AU Core 2.1.0-draft)

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:f608eaf403c8a681e15cdc361380d83bced54cca-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `f608eaf` → `a3d7a20` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`f608eaf`)
- feat(warmer): run validator warmer as a restart-triggered sidecar (not a timer) (#127)
- Add AU Core 2.1.0-preview (#130)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/f608eaf403c8a681e15cdc361380d83bced54cca...a3d7a2001aafa45da3ab40153bf109b5a601b6b8

- app:   `ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8-nginx`
