### PR TITLE
Promote prod → afa4bca (Update AU PS test kit to version 1.0.0)

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:afa4bcacb77823c3ff3a85bff71144b40ead0bf0
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:a3d7a2001aafa45da3ab40153bf109b5a601b6b8-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:afa4bcacb77823c3ff3a85bff71144b40ead0bf0-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `a3d7a20` → `afa4bca` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`a3d7a20`)
- Update AU PS test kit to version 1.0.0 and adjust dependencies (#132)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/a3d7a2001aafa45da3ab40153bf109b5a601b6b8...afa4bcacb77823c3ff3a85bff71144b40ead0bf0

- app:   `ghcr.io/hl7au/au-fhir-inferno:afa4bcacb77823c3ff3a85bff71144b40ead0bf0`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:afa4bcacb77823c3ff3a85bff71144b40ead0bf0-nginx`
