### PR TITLE
Right-size inferno-app, worker, and dev validator from event telemetry

### DIFF
--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -39,8 +39,12 @@ spec:
             name: postgresql-secret
         resources:
           requests:
-            memory: "512Mi"   # Actual usage: ~485Mi
-            cpu: "500m"       # Down from 250m - actual usage <10m, peaks at 52m
+            # Sparked event (07-01..09): the worker climbs and plateaus (Sidekiq
+            # retained heap, never released to the OS), reaching ~954Mi (prod) and
+            # ~805Mi (dev) and holding for ~2 days at 93% of the old 1Gi limit
+            # (44h above 80%). Not an unbounded leak, but no headroom. VPA 1168Mi.
+            memory: "768Mi"  # was 512Mi; steady plateau ~954Mi
+            cpu: "500m"       # actual usage <10m, peaks at 352m
           limits:
-            memory: "1Gi"   
+            memory: "1536Mi"  # was 1Gi; clears the ~954Mi plateau
             cpu: "1000m"

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -60,11 +60,16 @@ spec:
             name: postgresql-secret
         resources:
           requests:
-            memory: "2Gi"
+            # Memory right-sized from the Sparked event (07-01..09): inferno-app
+            # peaked 366Mi (prod), 350Mi (dev) and 228-348Mi across ~5 preview
+            # envs, vs the old 2Gi request (~5.5x over). This block is shared by
+            # every env, so the saving multiplies across all preview namespaces.
+            memory: "768Mi"
             cpu: "1000m"
           limits:
-            memory: "4Gi"
+            memory: "1536Mi"
             cpu: "2000m"
+# CPU (not memory) gates session-build latency, so it is left unchanged:
 # at 512Mi and 100m CPU takes 30sec to create new session
 # at 2Gi and 1000m CPU takes 9sec to create new session
       - name: nginx

--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -13,6 +13,16 @@ inferno:
 validator:
   replicas: 1
   storageClassName: "gp3-encrypted"
+  # Dev-only memory reclaim. During the Sparked event dev validator peaked
+  # 8.9Gi early (07-01/02) then settled to a 2.7-4.5Gi baseline for the rest of
+  # the window, so the base 10Gi request over-reserves ~4Gi here. Lower the
+  # request to cover the baseline and let the (unchanged) 12Gi limit absorb the
+  # occasional warm-cache burst burstably. Heap (-Xmx8g) is left alone so a real
+  # heavy dev validation still has room; this is a deliberate dev-only
+  # over-commit tradeoff, not applied to prod (prod peaked 9.4Gi, keeps 10Gi).
+  resources:
+    requests:
+      memory: "6Gi"
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Memory sizing from the Sparked testing event (07-01 to 07-09). The event was memory-bound.

- **inferno-app** requested 2Gi but peaked 366Mi (prod), 350Mi (dev) and 228-348Mi across ~5 preview envs. Request to 768Mi, limit to 1536Mi. This block is shared by every env, so the reclaim multiplies across all preview namespaces. CPU is left at 1000m/2000m because it, not memory, gates session-build latency (documented inline).
- **inferno-worker** ran at ~93% of its 1Gi limit for ~2 days (peak ~954Mi prod, ~805Mi dev; 44h above 80%). It is a grow-and-plateau pattern (Sidekiq retained heap), not a runaway leak, but it has no headroom. Request to 768Mi, limit to 1536Mi (VPA target 1168Mi); the stale '~485Mi' comment is corrected.
- **dev validator-api** over-reserved: it peaked 8.9Gi early then settled to a 2.7-4.5Gi baseline, so the dev request drops to 6Gi (`values-dev.yaml` only, deep-merged over base). The 12Gi limit and 8g heap are kept so a real heavy dev validation still bursts. **Prod is unchanged** (peaked 9.4Gi, keeps its 10Gi request).

Verified with `helm template` for both envs: dev validator 6Gi / prod validator 10Gi, inferno-app and worker updated in both.