### PR TITLE
Add PodDisruptionBudgets for multi-replica inferno workloads

### DIFF
--- a/infra/helm/inferno/templates/pdb.yaml
+++ b/infra/helm/inferno/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- /*
+PodDisruptionBudgets for multi-replica inferno workloads. Populated per environment via
+.Values.podDisruptionBudgets (empty by default). maxUnavailable is always used (never
+minAvailable) so a workload at its minimum replica count never blocks Karpenter
+consolidation or a node drain entirely, while a scaled-out workload loses at most one
+pod at a time to voluntary disruption.
+*/ -}}
+{{- range .Values.podDisruptionBudgets }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .app }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ .app }}
+spec:
+  maxUnavailable: {{ .maxUnavailable | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ .app }}
+{{- end }}

--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -44,3 +44,15 @@ postgresql:
     postgresql:
       auth:
         database: inferno
+
+# Cap voluntary disruption (Karpenter consolidation, node drain) to one pod at a time
+# for each replicated workload: worker and nginx run 2 replicas, redirect-nginx runs 2,
+# and inferno-app autoscales 1 to 6. maxUnavailable of 1 is permissive at 1 replica and
+# protective above it, and never blocks consolidation. inferno-redis and validator-api
+# are deliberately omitted: they are singletons whose protection is on-demand pinning,
+# not a no-op PDB.
+podDisruptionBudgets:
+  - app: inferno-app
+  - app: inferno-worker
+  - app: nginx-app
+  - app: redirect-nginx

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -115,3 +115,8 @@ postgresql:
         username: "postgres"
         password: "password"
         database: "inferno"
+
+# PodDisruptionBudgets for multi-replica workloads (rendered by templates/pdb.yaml).
+# Empty by default: dev and preview run single-replica, where a PDB is a no-op. Prod
+# populates this list in values-prod.yaml.
+podDisruptionBudgets: []


### PR DESCRIPTION
Part of the spot/consolidation hardening. The chart shipped no PDB, so Karpenter consolidation or a node drain could evict all replicas of a workload at once.

Adds a values-driven `templates/pdb.yaml` + a per-env `podDisruptionBudgets` list. **Prod** (values-prod) enables `maxUnavailable: 1` for inferno-app (HPA 1..6), inferno-worker (2), nginx-app (2), redirect-nginx (2) — permissive at 1 replica, protective above it, never blocks consolidation. **Dev/preview** stay single-replica with an empty list (a PDB there is a no-op). inferno-redis and validator-api are omitted (singletons protected by on-demand pinning, not a PDB).

Verified with `helm template`: prod renders 4 PDBs, dev renders 0.