### PR TITLE
Bound dev validator memory with session-cache expiry and LRU cap

### DIFF
--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -13,13 +13,34 @@ inferno:
 validator:
   replicas: 1
   storageClassName: "gp3-encrypted"
-  # Dev-only memory reclaim. During the Sparked event dev validator peaked
-  # 8.9Gi early (07-01/02) then settled to a 2.7-4.5Gi baseline for the rest of
-  # the window, so the base 10Gi request over-reserves ~4Gi here. Lower the
-  # request to cover the baseline and let the (unchanged) 12Gi limit absorb the
-  # occasional warm-cache burst burstably. Heap (-Xmx8g) is left alone so a real
-  # heavy dev validation still has room; this is a deliberate dev-only
-  # over-commit tradeoff, not applied to prod (prod peaked 9.4Gi, keeps 10Gi).
+  # Dev-only memory reclaim. Two independent knobs, both dev-only (prod keeps the
+  # base values.yaml settings). Heap (-Xmx8g) is left alone in both so a real heavy
+  # dev validation still has room.
+  #
+  # 1. requests.memory 10Gi to 6Gi (below): a scheduling/cost knob only. During the
+  #    Sparked event dev peaked 8.9Gi (07-01/02) then settled to a 2.7-4.5Gi baseline,
+  #    so the base 10Gi request over-reserves here. The (unchanged) 12Gi limit absorbs
+  #    the occasional warm-cache burst. Not applied to prod (prod peaked 9.4Gi).
+  #
+  # 2. sessionCache* (below): the actual-RSS knob, and the one that fixes the recurring
+  #    "Node Memory Saturation" page. requests.memory does NOT bound real memory, and
+  #    that alert measures actual RAM (100 * (1 - MemAvailable/MemTotal) > 90), so the
+  #    request cut alone never quieted it. With the base duration -1 (never expire) +
+  #    size 8, each distinct validation context builds a large resident ValidationEngine
+  #    (~0.8-1.5Gi) held until the pod restarts, so dev RSS ratchets monotonically
+  #    (4.3 to 5.1 to 6.7Gi over 07-13) and parks at the top. On the 8Gi dev node that
+  #    crosses the 90% line (RSS has to stay under ~6Gi). Dev runs on a cheap 8Gi node
+  #    and idles between test sessions, so:
+  #      - sessionCacheDuration: 30  re-enables idle expiry. Value is MINUTES
+  #        (Guava expireAfterAccess; -1 disables). Idle >30 min reclaims engines back
+  #        toward the JVM baseline. Prod keeps -1 for permanent warmth.
+  #      - sessionCacheSize: 5       LRU cap (warmer builds ~4 contexts + 1 spare); also
+  #        bounds the peak during active testing. Prod keeps 8.
+  #    Accepted dev-only trade-off: the first validation after a >30 min idle gap, or of
+  #    a context beyond the 5 resident, pays a ~50s cold engine rebuild. The warmer
+  #    sidecar only re-warms on validator restart, not on cache expiry.
+  sessionCacheDuration: 30
+  sessionCacheSize: 5
   resources:
     requests:
       memory: "6Gi"


### PR DESCRIPTION
## Problem

The dev validator node (`ip-10-0-14-254`, an 8Gi m6a.large that hosts `validator-api` essentially alone) keeps firing **Node Memory Saturation** (warning at `100 * (1 - MemAvailable/MemTotal) > 90`). It fired twice overnight (10:37 PM at 93.7%, 2:42 AM at 93.5%).

Root cause: the alert measures **actual RAM**, but the only dev memory tuning so far was lowering `requests.memory` (10Gi to 6Gi), a scheduling knob the alert does not measure. Meanwhile the validator's real RSS ratchets up and never recedes.

## Evidence (14-day Mimir history, `container_memory_working_set_bytes`, dev-inferno/validator-api)

| window | daily max |
|---|---|
| 06-29 to 07-02 (Sparked event) | 7.8 to 9.34G |
| 07-03 to 07-05 (fresh pod) | 2.85 to 2.90G |
| 07-06 to 07-12 | 3.6 to 4.5G |
| 07-13 | 4.3 → 5.1 → **6.7G**, then held |

The fine-grained trend is a **step ratchet, not a burst**: it climbs as distinct validation contexts are exercised and holds at the top until the pod restarts. `validator-api` is ~6.7G of the ~7.2G the whole namespace uses (everything else is <0.3G each).

The mechanism is the session cache: with `SESSION_CACHE_DURATION=-1` (never time-expire) and `SESSION_CACHE_SIZE=8`, each distinct context builds a large resident `ValidationEngine` (~0.8 to 1.5Gi here) that is retained until pod restart or LRU eviction at 8. On an 8Gi node the warning line is crossed once RSS passes ~6.0G.

## Change (dev-only; prod keeps base `values.yaml` settings)

- `validator.sessionCacheDuration: 30` — re-enable idle expiry. The value is **minutes** (upstream `GuavaSessionCacheAdapter` uses `expireAfterAccess(duration, TimeUnit.MINUTES)`; `-1` disables). Dev idles between test sessions, so engines reclaim toward the JVM baseline after 30 min idle.
- `validator.sessionCacheSize: 5` — LRU cap. The warmer builds ~4 contexts (`au_ps` + `au_core_v100/v200/v210_draft`), so 5 keeps the warmed set plus one spare and bounds the peak during active testing too.

Heap (`-Xmx8g`) and `requests.memory` (6Gi) are unchanged. Prod is untouched (keeps `-1` / size 8 for permanent warmth).

## Trade-off (accepted, dev only)

The first validation after a >30 min idle gap, or of a context beyond the 5 resident, pays a ~50s cold engine rebuild. The warmer sidecar only re-warms on validator restart, not on cache expiry, so post-idle cold starts in dev are expected. This is a deliberate dev cost-for-memory tradeoff; prod prioritises warmth.

## Alternative considered

Moving dev onto a 16Gi node (no cold starts, but more cost for a dev env and the opposite of reducing footprint). Not taken.