### PR TITLE
Promote prod → 767e3b6

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:767e3b6403d17569313e3ecec95c33a89572c2c5
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:767e3b6403d17569313e3ecec95c33a89572c2c5-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `d77a9a8` → `767e3b6` — staging already runs this exact artifact.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`d77a9a8`)
- Right-size inferno-app, worker, and dev validator from event telemetry (#135)
- Add PodDisruptionBudgets for multi-replica inferno workloads (#137)
- Use latest version of the AU PS Test Suite to fix the issue related to the references resolution (#138)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/d77a9a8027ef99978e3de79bba2da29a51e3071c...767e3b6403d17569313e3ecec95c33a89572c2c5

- app:   `ghcr.io/hl7au/au-fhir-inferno:767e3b6403d17569313e3ecec95c33a89572c2c5`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:767e3b6403d17569313e3ecec95c33a89572c2c5-nginx`
