### PR TITLE
Add SemVer releases + production deployment records to prod promotion

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -113,17 +113,27 @@ jobs:
       # for the newest master build and writes the tag to apps/inferno-dev/image-values.yaml
       # in that repo, which the inferno-dev Application consumes. So this workflow no longer
       # writes back to master at all — nothing here pushes to the trunk. Prod stays a PR.
-
-      # Prod promotion: push the SAME artifact's tags to a branch and surface a one-click
-      # PR link whose body is PREFILLED with a changelog + risk flags (deps / app / chart),
-      # diffed via the compare API between the SHA prod runs now and this build. Merging the
-      # PR = the prod release (human gate). ArgoCD (inferno-prod, targetRevision: master)
-      # syncs prod on merge. Prefill (vs auto-opening the PR) avoids needing "Actions can
-      # create PRs" AND keeps the PR human-authored so quality-control still runs on it.
+      #
+      # Prod promotion: push the SAME artifact's tags to a branch that bumps
+      # values-prod.yaml, then EITHER auto-open a draft PR (when a PROMOTE_TOKEN secret
+      # exists) OR surface a one-click prefilled compare link (fallback). Either way the PR
+      # body carries a changelog + risk flags (deps / app / chart) diffed via the compare
+      # API between the SHA prod runs now and this build, plus a proposed SemVer. Merging
+      # the PR = the prod release (human gate); prod-release.yaml then tags vX.Y.Z, aliases
+      # the images, and cuts a GitHub Release. ArgoCD (inferno-prod, targetRevision: master)
+      # syncs prod on merge.
+      #
+      # values-prod.yaml stays pinned to the immutable SHA (reproducible); vX.Y.Z is the
+      # human-facing release identity (git tag + Release + a semver image alias).
+      #
+      # PROMOTE_TOKEN must be a GitHub App token or fine-grained PAT (NOT the default
+      # GITHUB_TOKEN): PRs opened with GITHUB_TOKEN do not trigger further workflows, so
+      # quality-control would silently skip. Absent the secret we fall back to the link.
       - name: Prepare prod-promotion PR (changelog + risk flags)
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMOTE_TOKEN: ${{ secrets.PROMOTE_TOKEN }}
         run: |
           APP="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.app_tag }}"
           NGINX="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.config.outputs.nginx_tag }}"
@@ -133,6 +143,16 @@ jobs:
           # The SHA prod runs now = the image tag in values-prod.yaml BEFORE we bump it
           # (the staging step above reset the tree to the current master tip).
           PROD_SHA=$(grep -m1 'imageUrl:' infra/helm/inferno/values-prod.yaml | sed -E 's#.*:([0-9a-f]{7,40}).*#\1#' || true)
+
+          # Proposed next version = patch bump of the latest vX.Y.Z tag. The human sets the
+          # real version by editing the PR title (`... -> vX.Y.Z`) or applying a
+          # release:major|minor|patch label; prod-release.yaml resolves it at merge time.
+          LATEST_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v" \
+            --jq '[.[].ref | ltrimstr("refs/tags/") | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))]
+                  | sort_by(ltrimstr("v") | split(".") | map(tonumber)) | last // ""' 2>/dev/null || echo "")
+          [ -z "$LATEST_TAG" ] && LATEST_TAG="v0.0.0"
+          IFS='.' read -r MA MI PA <<< "${LATEST_TAG#v}"
+          PROPOSED="v${MA}.${MI}.$((PA + 1))"
 
           # Diff "what prod runs now" against this build via the compare API — works on a
           # shallow checkout, no deep clone needed. Build a changelog (drop merge/chore
@@ -161,10 +181,15 @@ jobs:
           git commit -am "chore: promote prod to ${GITHUB_SHA}"
           git push --force-with-lease origin "$BRANCH"
 
-          # Assemble the PR body, then prefill it into the one-click compare link.
+          # Assemble the shared PR body.
           BODY_FILE="${RUNNER_TEMP}/pr-body.md"
           {
             echo "Promote prod \`${PROD_SHA:0:7}\` → \`${GITHUB_SHA:0:7}\` — staging already runs this exact artifact."
+            echo ""
+            echo "## Release version"
+            echo "Proposed: **${PROPOSED}** (patch bump of \`${LATEST_TAG}\`)."
+            echo "To choose a different version, edit this PR's **title** to end with \`-> vX.Y.Z\`,"
+            echo "or apply a \`release:major\` / \`release:minor\` / \`release:patch\` label before merging."
             echo ""
             echo "## Risk flags"
             echo "- Dependencies / test kits (\`Gemfile.lock\`): **${DEPS}**"
@@ -180,22 +205,38 @@ jobs:
             echo "- nginx: \`${NGINX}\`"
           } > "$BODY_FILE"
 
-          TITLE=$(printf 'Promote prod → %s' "${GITHUB_SHA:0:7}" | jq -sRr @uri)
-          BODY=$(jq -sRr @uri < "$BODY_FILE")
-          LINK="${REPO_URL}/compare/master...${BRANCH}?expand=1&title=${TITLE}&body=${BODY}"
-          {
-            echo "## 🚀 Prod promotion ready"
-            echo ""
-            echo "**[Open the promotion PR — prefilled with changelog + risk flags](${LINK})**"
-            echo ""
-            echo "Merging it releases \`${GITHUB_SHA:0:7}\` to prod (the human gate)."
-            echo ""
-            echo "- app:   \`${APP}\`"
-            echo "- nginx: \`${NGINX}\`"
-            echo ""
-            echo "<details><summary>PR body preview</summary>"
-            echo ""
-            cat "$BODY_FILE"
-            echo ""
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
+          PR_TITLE="Promote prod -> ${PROPOSED}"
+
+          if [ -n "$PROMOTE_TOKEN" ]; then
+            # Auto-open a DRAFT PR with the elevated token so quality-control triggers.
+            # Idempotent: skip if a PR already exists for this branch (e.g. re-run).
+            EXISTING=$(GH_TOKEN="$PROMOTE_TOKEN" gh pr list --head "$BRANCH" --state open --json number --jq 'length')
+            if [ "$EXISTING" = "0" ]; then
+              PR_URL=$(GH_TOKEN="$PROMOTE_TOKEN" gh pr create \
+                --draft --base master --head "$BRANCH" \
+                --title "$PR_TITLE" --body-file "$BODY_FILE")
+            else
+              PR_URL=$(GH_TOKEN="$PROMOTE_TOKEN" gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url')
+            fi
+            {
+              echo "## 🚀 Prod promotion PR opened (draft)"
+              echo ""
+              echo "**${PR_URL}**"
+              echo ""
+              echo "Proposed version **${PROPOSED}**. Mark ready, review, and merge to release to prod (the human gate)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            # Fallback: one-click prefilled compare link (no PROMOTE_TOKEN provisioned).
+            TITLE=$(printf '%s' "$PR_TITLE" | jq -sRr @uri)
+            BODY=$(jq -sRr @uri < "$BODY_FILE")
+            LINK="${REPO_URL}/compare/master...${BRANCH}?expand=1&title=${TITLE}&body=${BODY}"
+            {
+              echo "## 🚀 Prod promotion ready"
+              echo ""
+              echo "**[Open the promotion PR — prefilled with changelog + risk flags](${LINK})**"
+              echo ""
+              echo "Proposed version **${PROPOSED}**. Merging releases \`${GITHUB_SHA:0:7}\` to prod (the human gate)."
+              echo ""
+              echo "> Tip: set a \`PROMOTE_TOKEN\` secret (GitHub App token or fine-grained PAT) to auto-open this PR as a draft."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -1,0 +1,203 @@
+# Prod release: fires when a prod-promotion PR (head `promote/prod-<sha>`) merges to
+# master. The merge is the release gate; this workflow makes the release legible and
+# verifiable:
+#   1. Resolve the SemVer (PR label release:* wins; else an explicit `-> vX.Y.Z` in the
+#      PR title; else a patch bump of the latest vX.Y.Z tag).
+#   2. Alias the already-built SHA-tagged images to the semver tag in ghcr (no rebuild).
+#   3. Create the annotated git tag + a GitHub Release (changelog since the previous tag).
+#   4. Record a deployment against the `production` Environment, wait for prod to come up
+#      on the new build, then mark the deployment success/failure.
+#
+# values-prod.yaml stays pinned to the immutable SHA (the promotion PR bumped it);
+# vX.Y.Z is the human-facing release identity + a convenience image alias. ArgoCD
+# (inferno-prod, targetRevision: master) performs the actual deploy on merge.
+name: Prod Release
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROD_URL: https://inferno.hl7.org.au
+
+concurrency:
+  group: prod-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only for a MERGED promotion PR.
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'promote/prod-')
+    permissions:
+      contents: write      # create git tag + GitHub Release
+      packages: write      # push the semver image alias to ghcr
+      deployments: write   # record the production deployment + status
+    steps:
+      - name: Checkout (merge commit)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0     # need tags to compute the changelog range
+
+      - name: Resolve release version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # The built image SHA is encoded in the promotion branch name.
+          BUILD_SHA="${HEAD_REF#promote/prod-}"
+
+          # Latest existing vX.Y.Z tag (bump base).
+          LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v" \
+            --jq '[.[].ref | ltrimstr("refs/tags/") | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))]
+                  | sort_by(ltrimstr("v") | split(".") | map(tonumber)) | last // ""' 2>/dev/null || echo "")
+          [ -z "$LATEST" ] && LATEST="v0.0.0"
+          IFS='.' read -r MA MI PA <<< "${LATEST#v}"
+
+          # Precedence: a release:* label overrides the title; otherwise an explicit
+          # `vX.Y.Z` in the PR title; otherwise a patch bump.
+          VER=""
+          case " $PR_LABELS " in
+            *" release:major "*) VER="v$((MA + 1)).0.0" ;;
+            *" release:minor "*) VER="v${MA}.$((MI + 1)).0" ;;
+            *" release:patch "*) VER="v${MA}.${MI}.$((PA + 1))" ;;
+          esac
+          if [ -z "$VER" ] && [[ "$PR_TITLE" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            VER="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+          fi
+          [ -z "$VER" ] && VER="v${MA}.${MI}.$((PA + 1))"
+
+          if gh release view "$VER" >/dev/null 2>&1; then
+            echo "Release $VER already exists — aborting to avoid clobbering." >&2
+            exit 1
+          fi
+
+          echo "version=$VER"      >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$LATEST"  >> "$GITHUB_OUTPUT"
+          echo "build_sha=$BUILD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved release version: $VER (prev $LATEST, build ${BUILD_SHA:0:7})"
+
+      - name: Log in to Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Alias SHA-tagged images to the semver tag
+        env:
+          VER: ${{ steps.ver.outputs.version }}
+          BUILD_SHA: ${{ steps.ver.outputs.build_sha }}
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${IMAGE_NAME}"
+          # Copy the existing manifests to semver tags (no rebuild, digest-identical).
+          docker buildx imagetools create -t "${IMG}:${VER}"        "${IMG}:${BUILD_SHA}"
+          docker buildx imagetools create -t "${IMG}:${VER}-nginx"  "${IMG}:${BUILD_SHA}-nginx"
+
+      - name: Create tag + GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VER: ${{ steps.ver.outputs.version }}
+          PREV: ${{ steps.ver.outputs.prev_tag }}
+          BUILD_SHA: ${{ steps.ver.outputs.build_sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/${IMAGE_NAME}"
+
+          # Changelog from local history (we fetched full history + tags). If the previous
+          # release tag exists use PREV..HEAD; otherwise (first release) cap at the last 40.
+          if git rev-parse -q --verify "refs/tags/${PREV}" >/dev/null 2>&1; then
+            RANGE_BASE="$PREV"
+            LOG=$(git log --no-merges --pretty=format:'%s' "${PREV}..${MERGE_SHA}")
+          else
+            RANGE_BASE=""
+            LOG=$(git log --no-merges -n 40 --pretty=format:'%s' "${MERGE_SHA}")
+          fi
+          CHANGELOG=$(printf '%s\n' "$LOG" \
+            | grep -viE 'skip ci|promote prod|^Merge (pull request|branch)' \
+            | sed 's/^/- /' )
+          [ -z "$CHANGELOG" ] && CHANGELOG="- (no user-facing commits)"
+
+          NOTES_FILE="${RUNNER_TEMP}/notes.md"
+          {
+            echo "## Changelog"
+            echo "${CHANGELOG}"
+            echo ""
+            echo "## Deployed artifact"
+            echo "- app:   \`${IMG}:${VER}\` (alias of \`${BUILD_SHA:0:12}\`)"
+            echo "- nginx: \`${IMG}:${VER}-nginx\`"
+            echo ""
+            if [ -n "$RANGE_BASE" ]; then
+              echo "**Full diff:** https://github.com/${GITHUB_REPOSITORY}/compare/${RANGE_BASE}...${VER}"
+            fi
+          } > "$NOTES_FILE"
+
+          gh release create "$VER" \
+            --target "$MERGE_SHA" \
+            --title "$VER" \
+            --notes-file "$NOTES_FILE"
+          echo "Created release $VER at ${MERGE_SHA:0:7}"
+
+      - name: Record production deployment
+        id: deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VER: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          DEP_ID=$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+            -f ref="$VER" \
+            -f environment=production \
+            -f description="Release $VER" \
+            -F auto_merge=false \
+            -F required_contexts='[]' \
+            --jq '.id')
+          echo "deployment_id=$DEP_ID" >> "$GITHUB_OUTPUT"
+          gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEP_ID}/statuses" \
+            -f state=in_progress -f environment=production \
+            -f environment_url="${PROD_URL}" -f description="ArgoCD syncing $VER" >/dev/null
+
+      - name: Wait for prod to serve the release
+        id: smoke
+        run: |
+          set -uo pipefail
+          # ArgoCD (inferno-prod) polls master ~every 3 min; give it up to ~10 min.
+          OK=0
+          for i in $(seq 1 20); do
+            CODE=$(curl -fsS -o /dev/null -w '%{http_code}' "${PROD_URL}/" 2>/dev/null || echo "000")
+            echo "attempt ${i}: HTTP ${CODE}"
+            if [ "$CODE" = "200" ]; then OK=1; break; fi
+            sleep 30
+          done
+          echo "ok=${OK}" >> "$GITHUB_OUTPUT"
+
+      - name: Finalise deployment status
+        if: always() && steps.deploy.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VER: ${{ steps.ver.outputs.version }}
+          DEP_ID: ${{ steps.deploy.outputs.deployment_id }}
+          OK: ${{ steps.smoke.outputs.ok }}
+        run: |
+          set -euo pipefail
+          if [ "${OK:-0}" = "1" ]; then STATE=success; DESC="prod serving $VER"; else STATE=failure; DESC="prod did not return 200 for $VER within the wait window"; fi
+          gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEP_ID}/statuses" \
+            -f state="$STATE" -f environment=production \
+            -f environment_url="${PROD_URL}" -f description="$DESC" >/dev/null
+          {
+            echo "## Prod release ${VER}"
+            echo "- deployment status: **${STATE}**"
+            echo "- ${DESC}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "$STATE" = "success" ]

--- a/docs/prod-releases.md
+++ b/docs/prod-releases.md
@@ -1,0 +1,61 @@
+# Prod releases (versioning + deployment records)
+
+Prod deploys via GitOps: ArgoCD (`inferno-prod`, `targetRevision: master`) syncs
+`infra/helm/inferno/values-prod.yaml`. The **merge of a promotion PR is the release gate**
+and the deploy trigger. This doc covers the release identity and audit trail layered on
+top of that flow.
+
+## Flow
+
+1. **Push to master** builds one released-flavour image tagged by commit SHA
+   (`build-and-release-package.yaml`). Staging auto-updates via ArgoCD Image Updater.
+2. The same workflow prepares a **prod-promotion PR** on branch `promote/prod-<sha>` that
+   bumps `values-prod.yaml` to the built SHA. The PR body carries a changelog, risk flags,
+   and a **proposed SemVer** (patch bump of the latest `vX.Y.Z` tag).
+   - If a `PROMOTE_TOKEN` secret exists, the PR is **auto-opened as a draft**.
+   - Otherwise a one-click prefilled compare link is printed in the run summary (fallback).
+3. A human sets the version and merges (the gate):
+   - **Default:** merge as-is to accept the proposed patch bump.
+   - **Different level:** apply a `release:major` / `release:minor` / `release:patch`
+     label (label wins over the title).
+   - **Explicit version:** edit the PR title to end with `-> vX.Y.Z` (used when no
+     `release:*` label is present).
+4. On merge, `prod-release.yaml`:
+   - resolves the version, aliases the SHA-tagged images to `vX.Y.Z` / `vX.Y.Z-nginx`
+     in ghcr (no rebuild, digest-identical),
+   - creates the annotated git tag + a **GitHub Release** (changelog since the previous tag),
+   - records a deployment against the **`production` Environment**, waits for
+     `https://inferno.hl7.org.au` to serve HTTP 200, then marks the deployment
+     success/failure.
+
+`values-prod.yaml` stays pinned to the **immutable SHA** (reproducible). `vX.Y.Z` is the
+human-facing release identity (git tag + Release + image alias + Environment record).
+
+## PROMOTE_TOKEN (auto-open the draft PR)
+
+The default `GITHUB_TOKEN` cannot be used: PRs it opens do **not** trigger further
+workflows, so `quality-control` would silently skip. Provision one of:
+
+- **GitHub App token (recommended):** install a small App with `contents:write` +
+  `pull_requests:write` on this repo, mint a token in-workflow with
+  `actions/create-github-app-token`, and expose it as `PROMOTE_TOKEN`. Not user-bound.
+- **Fine-grained PAT (pragmatic):** scope Contents + Pull requests to this repo, store as
+  the `PROMOTE_TOKEN` repo secret. Tied to the issuing user; rotate periodically.
+
+Absent the secret, the flow falls back to the prefilled compare link, so shipping this
+without a token is safe.
+
+## Rollback
+
+A release is an immutable target, so rollback is a one-line promotion PR: point
+`values-prod.yaml` (`imageUrl` / `platformImageUri`) back at the SHA of the prior release
+(shown in that release's notes) and merge. ArgoCD reverts prod on sync. Cut a new patch
+release from the rollback if you want the tag history to reflect it.
+
+## Why the merge is the gate (not an Environment approval)
+
+In GitOps, ArgoCD deploys from git regardless of whether any CI job ran. A GitHub
+Environment "required reviewers" rule only gates a GitHub Actions job, so it would be
+redundant with the promotion-PR review, not an additional gate. The `production`
+Environment here is therefore used for **deployment records and verification**, not as an
+approval gate. The gate is the human-merged, `quality-control`-checked promotion PR.


### PR DESCRIPTION
## What

Layers a proper **release identity** and **deployment audit trail** onto the existing GitOps prod flow. The human-merged promotion PR stays the release gate; this only makes what ships legible and verifiable.

### `build-and-release-package.yaml`
- Auto-opens the prod-promotion PR as a **draft** when a `PROMOTE_TOKEN` secret is present, else keeps today's one-click prefilled compare link (safe fallback).
- Computes a **proposed SemVer** (patch bump of the latest `vX.Y.Z` tag) into the PR title/body.

### `prod-release.yaml` (new, fires on promotion-PR merge)
- Resolves the version: `release:*` label > explicit `-> vX.Y.Z` in the PR title > patch bump.
- Aliases the SHA-tagged images to `vX.Y.Z` / `vX.Y.Z-nginx` in ghcr (no rebuild, digest-identical).
- Creates the git tag + **GitHub Release** with a changelog since the previous tag.
- Records a deployment against the **`production` Environment**, waits for `https://inferno.hl7.org.au` to serve HTTP 200, and marks the deployment success/failure.

`values-prod.yaml` stays pinned to the immutable SHA (reproducible); `vX.Y.Z` is the human-facing release identity.

## Why not an Environment approval gate

In GitOps, ArgoCD deploys from git regardless of whether a CI job ran, so a GitHub Environment "required reviewers" rule would be redundant with the promotion-PR review, not an extra gate. The `production` Environment is used here for **records + verification**, not approval. See `docs/prod-releases.md`.

## Follow-up to activate the draft-PR auto-open

Provision `PROMOTE_TOKEN` (GitHub App token recommended, fine-grained PAT as fallback). The default `GITHUB_TOKEN` cannot be used, as PRs it opens do not trigger `quality-control`. Provisioning steps are in `docs/prod-releases.md`.

## Validation
- YAML parses; `actionlint` clean apart from pre-existing warnings (unquoted `$GITHUB_OUTPUT` in the untouched `Set environment` step, `build-push-action@v2`).
- Version sort / bump / label-precedence / title-regex logic unit-tested under bash.