### PR TITLE
Scope CODEOWNERS to the prod deploy surface for the release gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,22 @@
-# Code owners — GitHub auto-requests these reviewers when matching files change.
-# NOTE: starting default only — replace with the real review owners/team.
-# Available maintainers: @ir4y @projkov @xmhorsehead @KyleOps @heathfrankel @Sudo-JHare
+# Code owners for the prod deploy gate.
 #
-# Enforcement (requiring owner review before merge) needs branch protection on
-# master, which is a repo-admin action — see the CI/CD overhaul plan (Track B).
+# In GitOps the merge to master IS the prod deploy, so owning the deploy surface
+# (Helm chart + values, dependencies, CI, image build) gates prod. When the master
+# ruleset has require_code_owner_review enabled, any PR touching these paths needs an
+# approving review from one of the listed owners before it can merge. Listing more than
+# one owner means ANY one of them satisfies the review (either can release).
+#
+# There is deliberately no `*` default owner: routine feature PRs (web/, lib/) only reach
+# staging on merge and still require the normal 1 review + quality-control; they do not
+# need a release owner. Code that reaches PROD goes through a promotion PR that bumps
+# infra/helm/inferno/values-prod.yaml, which is covered by /infra/ below.
+#
+# Available maintainers: @ir4y @projkov @xmhorsehead @KyleOps @heathfrankel @Sudo-JHare
+# TODO(release owners): add Brett's GitHub handle alongside @KyleOps on every line below,
+# then enable require_code_owner_review on the master ruleset.
 
-# Default owner for everything in the repo.
-*                       @KyleOps
-
-# Deployment + CI/CD surface.
-/.github/               @KyleOps
-/infra/                 @KyleOps
-/Dockerfile             @KyleOps
-/nginx.Dockerfile       @KyleOps
-/Gemfile                @KyleOps
-/Gemfile.lock           @KyleOps
-/Gemfile.common         @KyleOps
+/.github/          @KyleOps
+/infra/            @KyleOps
+/Dockerfile        @KyleOps
+/nginx.Dockerfile  @KyleOps
+/Gemfile*          @KyleOps


### PR DESCRIPTION
## What

Prepares the **code-owner review gate** that makes prod releases owned by a small set of release owners (Option A from the CI/CD discussion). In GitOps the merge to master is the prod deploy, so owning the deploy surface gates prod once the master ruleset enables `require_code_owner_review`.

- Drops the `*` default owner, so routine feature PRs (`web/`, `lib/`) keep the normal 1 review + `quality-control` and are **not** gated on a release owner.
- Owns the prod-affecting paths: `/.github/`, `/infra/`, Dockerfiles, `/Gemfile*`. A prod promotion PR bumps `infra/helm/inferno/values-prod.yaml`, covered by `/infra/`.
- Listing more than one owner means **any one** satisfies the review, so either release owner can approve.

## Remaining steps (not in this PR)

1. Add the second release owner's GitHub handle alongside `@KyleOps` on every line (Brett's handle needed).
2. After this merges to master, enable `require_code_owner_review: true` on the master ruleset (`18008660`). The ruleset reads CODEOWNERS from the base branch, so it must land first.
3. Set the `PROMOTE_TOKEN` repo secret to auto-open the promotion PR as a draft.

## How the gate then behaves

- Feature PR merged → staging auto-updates (the live preview).
- A draft `Promote prod -> vX.Y.Z` PR auto-opens; body = changelog + risk flags + link to staging.
- A release owner (either) approves + merges → prod syncs, the tag + GitHub Release are cut, and the `production` deployment record + health check run.
- Chart/template changes are covered too, since any `/infra/` PR requires a release owner.