### PR TITLE
Promote prod -> v1.0.0

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `d77a9a8` → `d0cbd6b` — staging already runs this exact artifact.

## Release version
Proposed: **v0.0.1** (patch bump of `v0.0.0`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`d77a9a8`)
- Right-size inferno-app, worker, and dev validator from event telemetry (#135)
- Add PodDisruptionBudgets for multi-replica inferno workloads (#137)
- Use latest version of the AU PS Test Suite to fix the issue related to the references resolution (#138)
- Bound dev validator memory with session-cache expiry and LRU cap (#139)
- Add SemVer releases + production deployment records to prod promotion (#141)
- Scope CODEOWNERS to the prod deploy surface for the release gate (#142)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/d77a9a8027ef99978e3de79bba2da29a51e3071c...d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9

- app:   `ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9-nginx`
