### PR TITLE
Promote prod -> v0.0.1

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:45cc826b4b102bb05d4cd8f54a3b48f5f8b63201
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d77a9a8027ef99978e3de79bba2da29a51e3071c-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:45cc826b4b102bb05d4cd8f54a3b48f5f8b63201-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `d77a9a8` → `45cc826` — staging already runs this exact artifact.

## Release version
Proposed: **v0.0.1** (patch bump of `v0.0.0`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`d77a9a8`)
- Right-size inferno-app, worker, and dev validator from event telemetry (#135)
- Add PodDisruptionBudgets for multi-replica inferno workloads (#137)
- Use latest version of the AU PS Test Suite to fix the issue related to the references resolution (#138)
- Bound dev validator memory with session-cache expiry and LRU cap (#139)
- Add SemVer releases + production deployment records to prod promotion (#141)
- Scope CODEOWNERS to the prod deploy surface for the release gate (#142)
- Add @brettesler-ext as a second release owner in CODEOWNERS (#144)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/d77a9a8027ef99978e3de79bba2da29a51e3071c...45cc826b4b102bb05d4cd8f54a3b48f5f8b63201

- app:   `ghcr.io/hl7au/au-fhir-inferno:45cc826b4b102bb05d4cd8f54a3b48f5f8b63201`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:45cc826b4b102bb05d4cd8f54a3b48f5f8b63201-nginx`
