### PR TITLE
Fix prod-release deployment record + stop spurious promotion PRs

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -9,9 +9,10 @@ on:
   push:
     branches:
       - master            # the trunk
-    paths-ignore:         # config-only pushes (image-tag write-backs, docs) must not rebuild
+    paths-ignore:         # config-only pushes must not rebuild / open a promotion PR
       - 'infra/**'
       - 'docs/**'
+      - '.github/**'       # CI, CODEOWNERS, templates: never change the app image
       - '*.md'
   pull_request:
     # Preview images for `preview`-labelled PRs (any base). PR quality gating lives in
@@ -218,6 +219,16 @@ jobs:
             else
               PR_URL=$(GH_TOKEN="$PROMOTE_TOKEN" gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url')
             fi
+
+            # Close any OLDER open promotion PRs — this build supersedes them (merging a
+            # stale one would deploy an older image and cut a lower version number).
+            NEW_NUM="${PR_URL##*/}"
+            for OLD in $(GH_TOKEN="$PROMOTE_TOKEN" gh pr list --state open --json number,headRefName \
+                --jq '.[] | select(.headRefName|startswith("promote/prod-")) | .number'); do
+              [ "$OLD" = "$NEW_NUM" ] && continue
+              GH_TOKEN="$PROMOTE_TOKEN" gh pr close "$OLD" \
+                --comment "Superseded by #${NEW_NUM} (newer prod promotion)." --delete-branch || true
+            done
             {
               echo "## 🚀 Prod promotion PR opened (draft)"
               echo ""

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -156,13 +156,13 @@ jobs:
           VER: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          DEP_ID=$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
-            -f ref="$VER" \
-            -f environment=production \
-            -f description="Release $VER" \
-            -F auto_merge=false \
-            -F required_contexts='[]' \
-            --jq '.id')
+          # Build the JSON payload explicitly: `gh api -F required_contexts='[]'` sends the
+          # STRING "[]", which the deployments API rejects (422 — not an array). auto_merge
+          # false + empty required_contexts force the deployment to be created directly
+          # rather than queued behind branch merges / status checks.
+          DEP_ID=$(jq -n --arg ref "$VER" --arg desc "Release $VER" \
+            '{ref:$ref, environment:"production", description:$desc, auto_merge:false, required_contexts:[]}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/deployments" --input - --jq '.id')
           echo "deployment_id=$DEP_ID" >> "$GITHUB_OUTPUT"
           gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEP_ID}/statuses" \
             -f state=in_progress -f environment=production \


### PR DESCRIPTION
Two bugs surfaced by the first live v1.0.0 release (#143).

## 1. prod-release deployment record (HTTP 422)
The deployment-record step sent `required_contexts` as the string `'[]'` via `gh api -F`, which the deployments API rejects (`"[]" is not an array or null`). Fixed by building the JSON payload with `jq` and passing it via `--input -` so `required_contexts` is a real empty array.

This step runs *after* the tag / GitHub Release / image-alias steps, so **v1.0.0 released fine**; only the deployment record failed. The corrected payload is verified against the live API, and I backfilled the missing v1.0.0 `production` deployment record (id `5436354963`, status success).

## 2. Spurious promotion PRs
`.github/**` wasn't in the build's `paths-ignore`, so the CODEOWNERS merges (#142, #144) each triggered a build and opened a promotion PR (that's where the stale #145 `v0.0.1` came from). Fixes:
- Add `.github/**` to `paths-ignore` (CI / CODEOWNERS / templates never change the app image).
- Auto-close older open `promote/prod-*` PRs when a new one opens (merging a stale one would deploy an older image and cut a lower version).

Closed the stale #145 manually.

## Notes
- This PR only touches `.github/**`, so with the new `paths-ignore` it won't trigger a build or a promotion PR itself.
- Prod is healthy on v1.0.0 (HTTP 200).