### PR TITLE
Promote prod -> v1.0.1

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `d0cbd6b` → `213f6c8` — staging already runs this exact artifact.

## Release version
Proposed: **v1.0.1** (patch bump of `v1.0.0`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **unchanged**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **unchanged** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`d0cbd6b`)
- Add @brettesler-ext as a second release owner in CODEOWNERS (#144)
- Fix prod-release deployment record + stop spurious promotion PRs (#146)
- align ps test kit page with gem version it is using

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/d0cbd6b9b2c624c798bc43b7a17b4fdb08f4d7f9...213f6c898b0b059a86a477f68f2248b926bea4d0

- app:   `ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0-nginx`
