### PR TITLE
Preview: AU PS R1 fixes (au-ps-inferno#99)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,5 @@ eval_gemfile 'Gemfile.common'
 gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
-# AU PS 1.0.0 IG (suite id au_ps_v100); pinned to a stable au-ps-inferno commit.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '540fcd72aa57297775fe6de2f57181c9ebdc5b19'
+# AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: 'd617981aaac4aa7b859e8b4500fa97f0e7e0a13e'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
 # AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: 'd617981aaac4aa7b859e8b4500fa97f0e7e0a13e'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '261e7440e93cce850fa182f51ff1b1bf56b6f4e4'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
 # AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '261e7440e93cce850fa182f51ff1b1bf56b6f4e4'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '94395b135bac2d6da760a6e6b2e41a351dd2d89f'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
 # AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '6dcd837cc648000ef541f0ae5ac307e426fc9f8c'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '0da4f73cdca9b4695790c3b93d6ff67905463aa7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
 # AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '94395b135bac2d6da760a6e6b2e41a351dd2d89f'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'au_core_test_kit', '~> 1.4.3'
 
 # AU PS test kit — no RubyGems release exists yet, so pin a stable commit. Targets the
 # AU PS 1.0.0 IG (suite id au_ps_v100); pinned to the 98-r1-fixes branch head for the R1 preview.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '6dcd837cc648000ef541f0ae5ac307e426fc9f8c'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: 'd617981aaac4aa7b859e8b4500fa97f0e7e0a13e'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '261e7440e93cce850fa182f51ff1b1bf56b6f4e4'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '6dcd837cc648000ef541f0ae5ac307e426fc9f8c'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '261e7440e93cce850fa182f51ff1b1bf56b6f4e4'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '94395b135bac2d6da760a6e6b2e41a351dd2d89f'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '540fcd72aa57297775fe6de2f57181c9ebdc5b19'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: 'd617981aaac4aa7b859e8b4500fa97f0e7e0a13e'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '6dcd837cc648000ef541f0ae5ac307e426fc9f8c'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '0da4f73cdca9b4695790c3b93d6ff67905463aa7'

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,4 @@ gem 'au_core_test_kit', '>= 1.4.3'
 
 # AU PS test kit — tracking master (incl. the noEcosystem perf fix). Re-point to a
 # bleeding-edge branch here when one is ready and verified.
-gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '94395b135bac2d6da760a6e6b2e41a351dd2d89f'
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno', ref: '01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a'

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
-  ref: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
+  revision: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
+  ref: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
-  ref: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
+  revision: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
+  ref: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
-  ref: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
+  revision: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
+  ref: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 540fcd72aa57297775fe6de2f57181c9ebdc5b19
-  ref: 540fcd72aa57297775fe6de2f57181c9ebdc5b19
+  revision: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
+  ref: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
-  ref: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
+  revision: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
+  ref: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
-  ref: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
+  revision: 0da4f73cdca9b4695790c3b93d6ff67905463aa7
+  ref: 0da4f73cdca9b4695790c3b93d6ff67905463aa7
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
-  ref: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
+  revision: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
+  ref: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
-  ref: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
+  revision: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
+  ref: 261e7440e93cce850fa182f51ff1b1bf56b6f4e4
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
-  ref: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
+  revision: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
+  ref: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 540fcd72aa57297775fe6de2f57181c9ebdc5b19
-  ref: 540fcd72aa57297775fe6de2f57181c9ebdc5b19
+  revision: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
+  ref: d617981aaac4aa7b859e8b4500fa97f0e7e0a13e
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
-  ref: 94395b135bac2d6da760a6e6b2e41a351dd2d89f
+  revision: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
+  ref: 01f2cc8652a5c5ccfd19f342bee62e4e731a2f3a
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-ps-inferno
-  revision: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
-  ref: 6dcd837cc648000ef541f0ae5ac307e426fc9f8c
+  revision: 0da4f73cdca9b4695790c3b93d6ff67905463aa7
+  ref: 0da4f73cdca9b4695790c3b93d6ff67905463aa7
   specs:
     au_ps_inferno (0.1.0)
       inferno_core (~> 1.0.6)


### PR DESCRIPTION
Preview environment for the AU PS R1 fix branch, for review of hl7au/au-ps-inferno#99 against the scenarios discussed in hl7au/au-ps-inferno#98.

Pins au_ps_inferno to the head of `98-r1-fixes` (d617981). No other dependency changes.

Not intended to merge as-is: once au-ps-inferno#99 is approved and merged, this pin moves to the merged master commit (or the release tag) through the normal release process.