### PR TITLE
Promote prod -> v1.0.2

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49
   usesWrapper: true
   # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
   # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
@@ -28,7 +28,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `213f6c8` → `0d05749` — staging already runs this exact artifact.

## Release version
Proposed: **v1.0.2** (patch bump of `v1.0.1`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **unchanged** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`213f6c8`)
- chore: update AU PS test kit to version 0.2.0 and adjust dependencies (#151)
- chore: update AU PS test kit version to 0.2.1 in Gemfile and documentation (#153)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/213f6c898b0b059a86a477f68f2248b926bea4d0...0d05749081407f8ac8f9bb730b99e83a40161e49

- app:   `ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49-nginx`
