### PR TITLE
chore: update AU Core test kit to provide an ability to use Endpoint IDs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ eval_gemfile 'Gemfile.common'
 # includes the AU Core 2.1.0-draft suite. Bump the lock (bundle update au_core_test_kit)
 # to adopt new 1.4.x releases.
 gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno',
-                        ref: '546c005b5301132c9daf21ffc8e66756c0638113'
+                        ref: 'b0bae19fdcd84427e1164009fdb4297ad9935f4f'
 
 # Released AU PS test kit (published on RubyGems by hl7au). '~> 0.2.1' means
 # >= 0.2.1, < 0.3.0; Gemfile.lock pins the exact version.

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ eval_gemfile 'Gemfile.common'
 # >= 1.4.3, < 1.5.0; Gemfile.lock pins the exact version. 1.4.3 is the first release that
 # includes the AU Core 2.1.0-draft suite. Bump the lock (bundle update au_core_test_kit)
 # to adopt new 1.4.x releases.
-gem 'au_core_test_kit', '~> 1.4.3'
+gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno',
+                        ref: '546c005b5301132c9daf21ffc8e66756c0638113'
 
 # Released AU PS test kit (published on RubyGems by hl7au). '~> 0.2.1' means
 # >= 0.2.1, < 0.3.0; Gemfile.lock pins the exact version.

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -14,7 +14,7 @@ eval_gemfile 'Gemfile.common'
 
 # Bleeding-edge AU Core test kit — unreleased commit ahead of the RubyGems release.
 gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno',
-                        ref: '546c005b5301132c9daf21ffc8e66756c0638113'
+                        ref: 'b0bae19fdcd84427e1164009fdb4297ad9935f4f'
 
 
 # Bleeding-edge AU PS test kit — unreleased commit ahead of the RubyGems release.

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -13,7 +13,8 @@
 eval_gemfile 'Gemfile.common'
 
 # Bleeding-edge AU Core test kit — unreleased commit ahead of the RubyGems release.
-gem 'au_core_test_kit', '>= 1.4.3'
+gem 'au_core_test_kit', git: 'https://github.com/hl7au/au-fhir-core-inferno',
+                        ref: '546c005b5301132c9daf21ffc8e66756c0638113'
 
 
 # Bleeding-edge AU PS test kit — unreleased commit ahead of the RubyGems release.

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -7,6 +7,16 @@ GIT
       inferno_core (>= 0.4.2)
 
 GIT
+  remote: https://github.com/hl7au/au-fhir-core-inferno
+  revision: 546c005b5301132c9daf21ffc8e66756c0638113
+  ref: 546c005b5301132c9daf21ffc8e66756c0638113
+  specs:
+    au_core_test_kit (1.4.3)
+      inferno_core (>= 1.0.6)
+      smart_app_launch_test_kit (>= 0.4.0)
+      tls_test_kit (~> 0.2.0)
+
+GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
   revision: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
   ref: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
@@ -30,10 +40,6 @@ GEM
     aes_key_wrap (1.1.0)
     anonymous_loader (0.1.2)
       version_gem (~> 1.1, >= 1.1.13)
-    au_core_test_kit (1.4.3)
-      inferno_core (>= 1.0.6)
-      smart_app_launch_test_kit (>= 0.4.0)
-      tls_test_kit (~> 0.2.0)
     au_ps_inferno (0.2.1)
       inferno_core (~> 1.0.6)
     auth-sanitizer (0.2.2)
@@ -43,7 +49,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bigdecimal (3.3.1)
-    bindata (2.5.1)
+    bindata (3.0.0)
     blueprinter (0.25.2)
     byebug (13.0.0)
       reline (>= 0.6.0)
@@ -522,7 +528,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  au_core_test_kit (>= 1.4.3)
+  au_core_test_kit!
   au_ps_inferno (>= 0.2.1)
   connection_pool (~> 2.5)
   database_cleaner-sequel (~> 1.8)

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-fhir-core-inferno
-  revision: 546c005b5301132c9daf21ffc8e66756c0638113
-  ref: 546c005b5301132c9daf21ffc8e66756c0638113
+  revision: b0bae19fdcd84427e1164009fdb4297ad9935f4f
+  ref: b0bae19fdcd84427e1164009fdb4297ad9935f4f
   specs:
-    au_core_test_kit (1.4.3)
+    au_core_test_kit (1.4.4)
       inferno_core (>= 1.0.6)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,16 @@ GIT
       inferno_core (>= 0.4.2)
 
 GIT
+  remote: https://github.com/hl7au/au-fhir-core-inferno
+  revision: 546c005b5301132c9daf21ffc8e66756c0638113
+  ref: 546c005b5301132c9daf21ffc8e66756c0638113
+  specs:
+    au_core_test_kit (1.4.3)
+      inferno_core (>= 1.0.6)
+      smart_app_launch_test_kit (>= 0.4.0)
+      tls_test_kit (~> 0.2.0)
+
+GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
   revision: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
   ref: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
@@ -30,10 +40,6 @@ GEM
     aes_key_wrap (1.1.0)
     anonymous_loader (0.1.2)
       version_gem (~> 1.1, >= 1.1.13)
-    au_core_test_kit (1.4.3)
-      inferno_core (>= 1.0.6)
-      smart_app_launch_test_kit (>= 0.4.0)
-      tls_test_kit (~> 0.2.0)
     au_ps_inferno (0.2.1)
       inferno_core (~> 1.0.6)
     auth-sanitizer (0.2.2)
@@ -43,7 +49,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bigdecimal (3.3.1)
-    bindata (2.5.1)
+    bindata (3.0.0)
     blueprinter (0.25.2)
     byebug (13.0.0)
       reline (>= 0.6.0)
@@ -522,7 +528,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  au_core_test_kit (~> 1.4.3)
+  au_core_test_kit!
   au_ps_inferno (~> 0.2.1)
   connection_pool (~> 2.5)
   database_cleaner-sequel (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/hl7au/au-fhir-core-inferno
-  revision: 546c005b5301132c9daf21ffc8e66756c0638113
-  ref: 546c005b5301132c9daf21ffc8e66756c0638113
+  revision: b0bae19fdcd84427e1164009fdb4297ad9935f4f
+  ref: b0bae19fdcd84427e1164009fdb4297ad9935f4f
   specs:
-    au_core_test_kit (1.4.3)
+    au_core_test_kit (1.4.4)
       inferno_core (>= 1.0.6)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)

--- a/web/_test_kits/au-core.md
+++ b/web/_test_kits/au-core.md
@@ -4,7 +4,7 @@ title: AU Core Test Kit
 test_kit_id: au_core_test_kit
 maturity: 1
 tags: [ AU ]
-date: 2026-07-06
+date: 2026-07-23
 version: 1.4.3
 canonical_url: "http://hl7.org.au/fhir/core"
 logo: /assets/images/au-core-logo.png

--- a/web/_test_kits/au-core.md
+++ b/web/_test_kits/au-core.md
@@ -4,8 +4,8 @@ title: AU Core Test Kit
 test_kit_id: au_core_test_kit
 maturity: 1
 tags: [ AU ]
-date: 2026-07-23
-version: 1.4.3
+date: 2026-07-24
+version: 1.4.4
 canonical_url: "http://hl7.org.au/fhir/core"
 logo: /assets/images/au-core-logo.png
 preview_text: The AU Core Test Kit validates the conformance of a server implementation to a specific version of the AU Core IG


### PR DESCRIPTION
Ref: https://github.com/hl7au/au-fhir-core-inferno/issues/296
