### PR TITLE
[DO NOT MERGE] A/B control: validator-wrapper 1.0.78 preview

### DIFF
--- a/VALIDATOR_OPTIMIZATION.md
+++ b/VALIDATOR_OPTIMIZATION.md
@@ -4,7 +4,9 @@ Documents all configuration decisions made to the HAPI FHIR validator-wrapper de
 
 ## Current Architecture
 
-The validator runs as a **StatefulSet** (2 replicas in prod, 1 in dev), each pod with its own persistent volumes for package and terminology caches. A Kubernetes Service with `sessionAffinity: ClientIP` ensures each Inferno pod always hits the same validator pod.
+The validator runs as a **single-pod Deployment** (`validator.replicas: 1`) with persistent volumes for the package and terminology caches, a `session-warmer` sidecar that rebuilds the Inferno-keyed session engines after a restart, and empty `presets.json` (no base-engine cloning). Heap is `-Xmx5g` with the wrapper's heap-pressure reload guard pinned low.
+
+> The StatefulSet + 2 replicas + `sessionAffinity: ClientIP` design described in §1 and §4 is **superseded**; see [§8](#8-2026-06-session-lifecycle-multi-pod-thrash-and-single-pod-deployment) for why it thrashed and [§10](#10-2026-07-heap-right-sizing-rss-is-not-the-working-set) for the current heap sizing. Sections below are kept in chronological order as a decision record, not as current-state documentation.
 
 ---
 
@@ -296,6 +298,67 @@ Prod AU Core runs intermittently 500'd with `java.lang.Error: Unable to resolve 
 **Fix — stop cloning: empty `presets.json`** (`templates/configs/validator-presets-configmap.yaml` → `[]`). With no matching preset, `ValidationService.getValidationEngineFromParameters` takes the `buildValidationEngine()` fallback and builds the session **fresh from the request's `igs`** via `CanonicalResourceManager.see()`, which populates `url|version` keys correctly and never touches the shallow `copy()`. The `au_core_test_kit` suites still send `baseEngine AU_CORE_V*`; an unknown key is silently ignored (verified live: unknown `baseEngine` + real `igs` → HTTP 200, resolves). LRU eviction and heap reload also recreate fresh from the stored cliContext, so no clone path remains. A `checksum/presets` annotation on the validator Deployment rolls the pod when this ConfigMap changes (the wrapper reads presets only at startup). Cost is a fresh ~35–50s build for the first session per suite after a restart — but cloning gave no real speedup on these core versions (§8) and the warmer pre-warms after restart. Restore the presets only once upstream `copy()` deep-copies all indexes.
 
 **Immediate mitigation** when a poisoned session is live: `kubectl rollout restart deploy/validator-api -n <ns>` drops the in-memory cache; the next run rebuilds a clean session.
+
+### 10. 2026-07: heap right-sizing — RSS is not the working set
+
+Every memory decision before this point (§1's sizing, §6's `SESSION_CACHE_SIZE` note, the dev-only reclaim in `values-dev.yaml`) read **RSS** and concluded the validator needed 10-12Gi. RSS was the wrong signal. G1 commits heap on demand and **never uncommits it** without periodic-GC tuning, so the pod parks at the `-Xmx` ceiling forever regardless of how much data is actually live. The `-Xmx8g` setting was manufacturing the 8.9Gi RSS it was then justified by.
+
+**What the telemetry actually says.** Thirty days of prod (`jvm_memory_used_after_last_gc_bytes`, the live set after each collection, via the OTel Java agent to Mimir):
+
+| Metric | Value |
+|---|---|
+| **Live heap after GC** | **2083Mi**, flat within ±3% for 18 days (Old Gen pinned at 2021Mi) |
+| Committed heap | 8192Mi, constant, never uncommits |
+| Used heap (live + garbage) | sawtooths 3037 → 7339Mi |
+| Non-heap (metaspace + code) | 208Mi |
+| Container working set | 8889Mi, flat for 11 days |
+| Request / limit (before) | 10Gi / 12Gi |
+| Restarts / OOMKills, 30d | **0 / 0** |
+| GC pause fraction | p95 0.00, max 0.03 |
+| CPU | 2m idle; peak utilisation ratio 0.16 |
+
+So `8889Mi RSS = 8192Mi committed heap + 208Mi non-heap + ~490Mi native/JIT/threads`, against a **true working set of ~2.3Gi**. That is also mechanically consistent: ~5 warm contexts against a flat 2021Mi live Old Gen puts one resident `ValidationEngine` at **~400Mi**, so the 8-slot `SESSION_CACHE_SIZE` worst case is ~3.2Gi.
+
+**§9's fix is visible in the same data,** which is the strongest confirmation it worked. Daily max live heap:
+
+```
+06-25  691Mi   06-29 3190Mi   07-03 1827Mi   07-07 2217Mi   07-15 2057Mi   07-21 2079Mi
+06-26  688Mi   06-30 3162Mi   07-04    0Mi   07-08 2054Mi   07-16 2071Mi   07-22 2083Mi
+06-27  690Mi   07-01 3267Mi   07-05    0Mi   07-09 2028Mi   07-17 2081Mi   07-23 2091Mi
+06-28  688Mi   07-02 6064Mi   07-06   58Mi   07-10 2031Mi   07-18 2075Mi   07-24 2091Mi
+                    ^^^^^^ pre-fix peak                                     07-25 2083Mi
+```
+
+The 6064Mi peak on 07-02 sits exactly on the rollout of #121 (pin 1.0.78) and **#123 (drop base-engine presets)**, both 2026-07-01. That same day carries **76 `Unable to resolve profile` log lines and every other day of the month carries zero**. So the peak is the clone-desync configuration dying, not a representative load peak — resident base engines plus cloned session engines is precisely what §9 removed. From 07-07 the current config is flat at ~2.05Gi.
+
+**The coupled trap: `VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD`.** From `ValidationServiceFactoryImpl.getValidationService()` in the wrapper:
+
+```kotlin
+val freeMemory = Runtime.getRuntime().freeMemory()
+if (freeMemory < validationServiceConfig.engineReloadThreshold) { ...
+    validationService = createEmptyValidationServiceInstance()   // discards ALL cached sessions
+    System.gc()
+    validationService = createValidationServiceInstance() }
+```
+
+The value is in **bytes** (`application.conf`: `engine-reload-threshold = 250000000`, so 250 MB), and `Runtime.freeMemory()` is free-within-**committed** heap, not free-within-`-Xmx`. On a right-sized heap that number is naturally near zero immediately before any ordinary collection. At `-Xmx8g`, committed stayed pinned at 8192Mi and the sawtooth floor left ~850Mi free, always above 250 MB — which is the only reason this never fired in prod (confirmed: zero reload log lines in 30 days of Loki). **Cutting the heap without cutting this would make healthy GC behaviour wipe every warm session on a 5-minute cooldown (`RELOAD_COOLDOWN_MS`), re-introducing the ~50s cold rebuild.** The oversized heap was accidentally load-bearing.
+
+**What changed:**
+
+| Setting | Before | After |
+|---|---|---|
+| `validator.javaOpts` | `-Xmx8g` | **`-Xmx5g`** (~2.4x steady live, ~1.5x the 8-slot worst case) |
+| `validator.engineReloadThreshold` | *(unset → 250000000)* | **`10000000`** (10 MB) — last-resort guard only |
+| `validator.resources.requests.memory` | `10Gi` | **`6Gi`** |
+| `validator.resources.limits.memory` | `12Gi` | **`8Gi`** |
+
+Dropping the reload threshold is safe here because the 30-day Old Gen trace is flat: there is no leak or drift for that valve to relieve, and a genuine OOM is already covered by the container limit, the restart, and the warmer sidecar rebuilding sessions. Leaving it at the default while shrinking the heap is the actively dangerous combination.
+
+**Not done, and why.** Periodic-GC uncommit (`-XX:G1PeriodicGCInterval`, `MaxHeapFreeRatio`) would let RSS track the live set with a larger `-Xmx` for burst headroom, but it fights the same `freeMemory()` heuristic from the other direction — shrinking committed heap is exactly what trips the reload. Not worth it while the wrapper keeps that check.
+
+**Rule for future sizing: measure `jvm_memory_used_after_last_gc_bytes`, never RSS or `kubectl top`.** On a JVM with a fixed `-Xmx` and no periodic GC, RSS tells you what you configured, not what you need.
+
+---
 
 ## Managing PVCs
 

--- a/VALIDATOR_OPTIMIZATION.md
+++ b/VALIDATOR_OPTIMIZATION.md
@@ -165,7 +165,7 @@ Prod's default jar presets (DEFAULT/IPS/IPS_AU/CDA/US_CCDA) load in seconds but 
 
 **Fresh PVC benefit (rolling updates):** Without presets, the first user after a pod replacement waits for network package downloads (~1–2 min). With presets, downloads happen during the startup window before the readiness probe passes — users never see them.
 
-**Updating presets when IG versions change:** Edit `validator-presets-configmap.yaml` and roll the StatefulSet. The new pod downloads the new packages during its startup window.
+**Updating presets when IG versions change:** Edit `validator-presets-configmap.yaml` and roll the workload (`kubectl rollout restart deploy/validator-api -n <ns>` — it is a Deployment since §8, not a StatefulSet; a `checksum/presets` annotation also rolls it automatically when the ConfigMap changes). The new pod downloads the new packages during its startup window. **Superseded by §9: `presets.json` is intentionally empty, so there is nothing to update here today.**
 
 **How the JVM warming and `baseEngine` work (source-verified from validator-wrapper):**
 
@@ -283,7 +283,9 @@ This comes up because the validator-wrapper *does* ship a self-warm feature (pre
 
 **In one line:** warming is external-by-necessity, not by preference — the validator can persist packages/terminology and hold a session open, but it cannot *originate* the Inferno-keyed session that production traffic reuses, and its only built-in shortcut for doing so (preset base-engine cloning) is both a no-op on cost here and the cause of the bug we removed.
 
-**Useful wrapper ops endpoints:** `GET /validator/presets` (loaded base engines), `/validator/engines` (cached sessions), `/txStatus`, `/packStatus`, `/validator/version`.
+**Useful wrapper ops endpoints:** `GET /validator/presets` (loaded base engines — returns `[]` for us, per §9), `/txStatus`, `/packStatus`, `/validator/version`.
+
+> `/validator/engines` (cached sessions) was listed here but **404s on 1.0.78 and 1.0.81** (verified 2026-07-25). There is no supported endpoint for enumerating cached sessions on the deployed versions; use the `Cached session exists` log lines instead. The container image has no `curl`, so probe from the `session-warmer` sidecar (which has Python) or via `kubectl port-forward`.
 
 ---
 
@@ -291,9 +293,23 @@ This comes up because the validator-wrapper *does* ship a self-warm feature (pre
 
 Prod AU Core runs intermittently 500'd with `java.lang.Error: Unable to resolve profile http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient|<version>` (from `ValidationEngine.asSdList`), always on a **reused/cached** session (`Cached session exists …`), never on a fresh session. Initially only **v1.0.0** failed (v2.0.0 fine); after the wrapper bump below it flipped to **v2.0.0** failing (v1.0.0 fine) — the tell that it's a *co-residency* defect, not a version-specific one.
 
-**Root cause — the base-engine clone path.** A "preset" preloads a base `ValidationEngine`; when a request's `baseEngine` names a preset, the wrapper serves the session by CLONING that base engine (`new ValidationEngine(other)` → `SimpleWorkerContext(other)` → `BaseWorkerContext.copy()` → `CanonicalResourceManager.copy()`), and **ignores the request's `igs` entirely**. `CanonicalResourceManager.copy()` is shallow — in 6.6.3 it copied neither `listForUrl` nor `listForId`; even after 6.9.7 fixed `listForUrl` (commit `3a08028b3b`, [org.hl7.fhir.core#2327](https://github.com/hapifhir/org.hl7.fhir.core/pull/2327)) it still does **not** copy `listForId`/`supplements`, so the clone's canonical indexes stay internally inconsistent. A later `drop()`/reindex on the clone corrupts the exact `url|version` key; `get(url, version)` is strict (tries `url|version` then `url|majmin`, **no** bare-url fallback), so resolution returns null for the life of that cached session. With AU Core 1.0.0 and 2.0.0 both loaded, whichever version isn't the current bare-url "winner" rides the fragile per-version key and is the one that breaks.
+**Root cause — the base-engine clone path.** A "preset" preloads a base `ValidationEngine`; when a request's `baseEngine` names a preset, the wrapper serves the session by CLONING that base engine (`new ValidationEngine(other)` → `SimpleWorkerContext(other)` → `BaseWorkerContext.copy()` → `CanonicalResourceManager.copy()`), and **ignores the request's `igs` entirely**. `CanonicalResourceManager` maintains **six** collections and `copy()` populates only **three**:
 
-**Wrapper 1.0.78 (core 6.9.7) — necessary but NOT sufficient.** The bump was still made and kept (it fixes the `listForUrl` half of `copy()` and adds a `ReentrantLock` + 5-min cooldown on the heap-pressure engine reload that 1.0.68 fired unconditionally per request under `freeMemory() < VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD`, ~238 MB default — which had multiplied clone churn). But the residual shallow-copy of `listForId`/`supplements` still desynced clones, so the error reappeared on v2.0.0.
+| Field | populated by `see()` | copied by `copy()` |
+|---|---|---|
+| `allResources`, `indexedResources` | ✓ | ✓ |
+| `listForUrl` | ✓ | ✓ *(added in 6.9.7, [#2327](https://github.com/hapifhir/org.hl7.fhir.core/pull/2327))* |
+| `listForId`, `masterDefinitions`, `supplements` | ✓ | **✗** |
+
+So a cloned manager holds every resource but three empty indexes, and `copy()`'s only caller is the clone-constructor chain, which never reindexes afterwards.
+
+The clearest consequence is `masterDefinitions`, consulted **first** on bare-URL resolution (`CanonicalResourceManager.get(String url)`): `see()` populates it for master-package CodeSystems/ValueSets and specializing StructureDefinitions, so it encodes **master-package precedence for a versionless canonical**. In a clone it is empty, so `get(url)` silently skips that precedence and returns whatever `indexedResources` holds instead. With AU Core 1.0.0 and 2.0.0 co-resident that flips which version wins for a bare canonical — which is why the failure *moved* between versions rather than staying on one, the tell that it is a co-residency defect.
+
+> Corrected 2026-07-25. This section previously attributed the fault to `listForId` plus a corrupted `url|version` key. `listForId` is indeed not copied, but `masterDefinitions` is the field on the primary resolution path and is the better-supported mechanism. The precedence-flip explanation is **inferred from source, not reproduced in an isolated test** — see the caveats in [docs/issues/upstream-canonicalresourcemanager-copy.md](docs/issues/upstream-canonicalresourcemanager-copy.md), which is the full brief for reporting this upstream.
+
+**Wrapper 1.0.78 (core 6.9.7) — necessary but NOT sufficient.** The bump was still made and kept (it fixes the `listForUrl` third of `copy()` and adds a `ReentrantLock` + 5-min cooldown on the heap-pressure engine reload that 1.0.68 fired unconditionally per request under `freeMemory() < VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD`, 250 MB default — which had multiplied clone churn). But the residual shallow copy still desynced clones, so the error reappeared on v2.0.0.
+
+**Still unfixed at core 6.9.12 (wrapper 1.0.81).** Verified 2026-07-25: `CanonicalResourceManager.copy()` at tag `6.9.12` is **byte-identical** to `6.9.7`. `listForId`, `masterDefinitions` and `supplements` are still not copied. A search of upstream issues and PRs found nothing covering this (the nearest, [#2484](https://github.com/hapifhir/org.hl7.fhir.core/issues/2484), is a different `listForId` bug in `drop()`). **Do not re-enable presets on the strength of a core bump** without re-reading that method — and note §8 measured `baseEngine` cloning as giving no speedup anyway, so a fix alone is not a reason to re-enable.
 
 **Fix — stop cloning: empty `presets.json`** (`templates/configs/validator-presets-configmap.yaml` → `[]`). With no matching preset, `ValidationService.getValidationEngineFromParameters` takes the `buildValidationEngine()` fallback and builds the session **fresh from the request's `igs`** via `CanonicalResourceManager.see()`, which populates `url|version` keys correctly and never touches the shallow `copy()`. The `au_core_test_kit` suites still send `baseEngine AU_CORE_V*`; an unknown key is silently ignored (verified live: unknown `baseEngine` + real `igs` → HTTP 200, resolves). LRU eviction and heap reload also recreate fresh from the stored cliContext, so no clone path remains. A `checksum/presets` annotation on the validator Deployment rolls the pod when this ConfigMap changes (the wrapper reads presets only at startup). Cost is a fresh ~35–50s build for the first session per suite after a restart — but cloning gave no real speedup on these core versions (§8) and the warmer pre-warms after restart. Restore the presets only once upstream `copy()` deep-copies all indexes.
 
@@ -362,11 +378,15 @@ Dropping the reload threshold is safe here because the 30-day Old Gen trace is f
 
 ## Managing PVCs
 
-StatefulSet PVCs persist after pod deletion and must be removed manually if a full reset is needed:
+The cache PVCs persist after pod deletion and must be removed manually if a full reset is needed. Since §8 they are ordinary named PVCs on a Deployment, **not** StatefulSet `volumeClaimTemplates`:
 
 ```bash
-kubectl delete pvc -n <namespace> -l app=validator-api
+kubectl delete pvc -n <namespace> validator-fhir-package-cache validator-terminology-cache
 ```
+
+> This previously documented `kubectl delete pvc -n <namespace> -l app=validator-api`. **That selector matches nothing** — the PVCs carry no `app` label, so the command silently deleted nothing and appeared to succeed (verified against prod, 2026-07-25). Delete by name.
+
+Deleting the package cache forces a re-download of all IG packages on next startup; deleting the terminology cache re-introduces the slow-concurrency cold-tx behaviour measured in [docs/validator-benchmarking.md](docs/validator-benchmarking.md) until it re-warms.
 
 Deleting PVCs forces re-download of all packages on next startup (~30–60 seconds with current CPU allocation).
 

--- a/docs/issues/upstream-canonicalresourcemanager-copy.md
+++ b/docs/issues/upstream-canonicalresourcemanager-copy.md
@@ -1,0 +1,163 @@
+# Upstream brief: `CanonicalResourceManager.copy()` is an incomplete clone
+
+**Status:** investigated, not yet reported upstream. Prepared as a self-contained brief so
+an upstream issue/PR can be raised without re-deriving any of it.
+
+**Repo:** [`hapifhir/org.hl7.fhir.core`](https://github.com/hapifhir/org.hl7.fhir.core)
+**File:** `org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/CanonicalResourceManager.java`
+**Verified at:** tags `6.9.7` and `6.9.12` (identical), 2026-07-25
+**Our exposure:** [`VALIDATOR_OPTIMIZATION.md` §9](../../VALIDATOR_OPTIMIZATION.md) — worked around locally by shipping an empty `presets.json`
+
+> Raise this upstream only with the verification in "Before filing" done. The repo has a
+> high scrutiny bar and this brief deliberately stops short of claims that are inferred
+> rather than proven. Everything below marked **VERIFIED** was read from source at the
+> stated tag; everything marked **INFERRED** has not been reproduced in a test.
+
+---
+
+## 1. The defect
+
+`CanonicalResourceManager` maintains **six** collections. `copy()` populates **three**.
+
+```java
+// CanonicalResourceManager.java:301-309 @ 6.9.12
+public void copy(CanonicalResourceManager<T> source) {
+  allResources.clear();
+  indexedResources.clear();
+  allResources.addAll(source.allResources);
+  indexedResources.putAll(source.indexedResources);
+  for (Map.Entry<String, List<CachedCanonicalResource<T>>> entry : source.listForUrl.entrySet()) {
+    listForUrl.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+  }
+}
+```
+
+| Field | decl. | populated by `see()` | copied by `copy()` |
+|---|---|---|---|
+| `allResources` | `:269` | ✓ `:393` | ✓ |
+| `listForId` | `:270` | ✓ `:387-391` | **✗** |
+| `listForUrl` | `:271` | ✓ `:401` | ✓ *(added 6.9.7, [#2327](https://github.com/hapifhir/org.hl7.fhir.core/pull/2327))* |
+| `masterDefinitions` | `:272` | ✓ `:399` | **✗** |
+| `indexedResources` | `:273` | ✓ | ✓ |
+| `supplements` | `:274` | ✓ `:405` (`addToSupplements`) | **✗** |
+
+**VERIFIED.** `copy()` at `6.9.12` is byte-identical to `6.9.7`; #2327 fixed only `listForUrl`.
+
+Also not copied: the `enforceUniqueId` and `minimalMemory` configuration flags (`:267-268`),
+and `loadCount` (`:29`). `enforceUniqueId` gates the `listForId` write at `:386`, so a clone
+whose flag defaults differently from its source would diverge further.
+
+## 2. Why `copy()` is the right place to fix it
+
+`CanonicalResourceManager.copy()` has exactly **one** call site, and it is a clone
+constructor chain with no post-copy index rebuild:
+
+```
+ValidationEngine(ValidationEngine other)                    org.hl7.fhir.validation
+  └─ new SimpleWorkerContext(other)                         SimpleWorkerContext.java:213
+       └─ copy(other)                                                             :223
+            └─ super.copy(other)  = BaseWorkerContext.copy()  BaseWorkerContext.java:354
+                 └─ .copy() on 14 CanonicalResourceManager instances          :357-379
+                    (codeSystems, valueSets, maps, transforms, structures,
+                     searchParameters, plans, questionnaires, operations,
+                     systems, guides, capstmts, measures, libraries)
+```
+
+**VERIFIED.** `BaseWorkerContext.copy()` otherwise copies ~30 fields explicitly and does not
+reindex afterwards, so the method's only contract is "produce an equivalent manager". This is
+a core defect; it is not caused by, and cannot be fixed in, any downstream wrapper.
+
+## 3. Observable consequence
+
+The clearest path is `masterDefinitions`, consulted **first** on bare-URL resolution:
+
+```java
+// CanonicalResourceManager.java:713-719
+public T get(String url) {
+  CachedCanonicalResource<T> cr = masterDefinitions.get(url);   // empty in a clone
+  if (cr != null) return cr.getResource();
+  return indexedResources.containsKey(url) ? indexedResources.get(url).getResource() : null;
+}
+```
+
+`see()` at `:396-401` puts a resource into `masterDefinitions` when its package
+`isMaster()` and it is a `CodeSystem`/`ValueSet`, or a `StructureDefinition` with
+derivation `specializes`, excluding `http://terminology.hl7.org`. That map therefore
+encodes **master-package precedence for a bare canonical URL**.
+
+In a clone the map is empty, so `get(url)` silently skips that precedence and returns
+whatever `indexedResources` holds. **INFERRED:** with two versions of one IG co-resident
+(our case: AU Core 1.0.0 and 2.0.0), this flips which version wins for a versionless
+canonical. That is consistent with the symptom in §9 — the failure moved from v1.0.0 to
+v2.0.0 after a wrapper bump, i.e. a co-residency defect rather than a version-specific one —
+but we have **not** reproduced it in an isolated test.
+
+`getByPackage(String url, List<String> pvlist)` at `:781` consults `masterDefinitions` the
+same way.
+
+`listForId` and `supplements` are similarly consulted at `:654` and `:886`/`:896`.
+
+## 4. Adjacent, already-tracked bug (do not conflate)
+
+`:615` `while (listForId.values().remove(cr));` carries an in-source `FIXME`: SpotBugs
+`GC_UNRELATED_TYPES`, always false because `values()` is `Collection<List<...>>`, not
+`Collection<CachedCanonicalResource<T>>`. So `drop()` never removes from `listForId`.
+Tracked upstream as open issue
+[#2484](https://github.com/hapifhir/org.hl7.fhir.core/issues/2484) ("FIXME: SpotBugs
+GC_UNRELATED_TYPES"). **This is a different bug.** Keep them separate in any report.
+
+## 5. Prior art search
+
+Searched `repo:hapifhir/org.hl7.fhir.core` issues and PRs for `CanonicalResourceManager`
+(2026-07-25). Related but distinct: #2484 (SpotBugs FIXME, open), #2331 (cache `getList`,
+closed), #2322 (O(1) `drop`, closed), #2166 (concurrency, closed), #2327 (the partial
+`listForUrl` fix, merged). **Nothing covers the incomplete `copy()`.**
+
+## 6. Candidate fix
+
+```java
+public void copy(CanonicalResourceManager<T> source) {
+  allResources.clear();
+  indexedResources.clear();
+  listForId.clear();
+  listForUrl.clear();
+  masterDefinitions.clear();
+  supplements.clear();
+
+  allResources.addAll(source.allResources);
+  indexedResources.putAll(source.indexedResources);
+  masterDefinitions.putAll(source.masterDefinitions);
+  for (Map.Entry<String, List<CachedCanonicalResource<T>>> e : source.listForUrl.entrySet())
+    listForUrl.put(e.getKey(), new ArrayList<>(e.getValue()));
+  for (Map.Entry<String, List<CachedCanonicalResource<T>>> e : source.listForId.entrySet())
+    listForId.put(e.getKey(), new ArrayList<>(e.getValue()));
+  for (Map.Entry<String, List<CachedCanonicalResource<T>>> e : source.supplements.entrySet())
+    supplements.put(e.getKey(), new ArrayList<>(e.getValue()));
+}
+```
+
+Note the existing method does not `clear()` `listForUrl` before writing into it; the added
+`clear()` calls make the copy total rather than additive. Whether `enforceUniqueId` /
+`minimalMemory` should also be carried over is a **question for the maintainers**, not
+something to assert — changing them alters `see()` behaviour on the clone.
+
+## 7. Before filing
+
+1. **Reproduce in a unit test in-repo.** Build a manager via `see()` with two versions of one
+   canonical from different packages (one master), `copy()` it, and assert `get(url)` returns
+   the same resource from both. This is the single most important missing piece — everything
+   in §3 beyond the source reading is inference.
+2. **Check `main`**, not just `6.9.12`; it may have moved.
+3. **Decide the `enforceUniqueId` / `minimalMemory` question** or explicitly leave it to
+   maintainers in the issue text.
+4. **Do not bundle #2484.** File the `copy()` gap on its own.
+5. Frame it as extending #2327 (same author's fix, same method, remaining fields) rather than
+   as a new discovery — that is accurate and lowers review friction.
+
+## 8. What this means for us either way
+
+Our workaround (empty `presets.json`, §9) removes the clone path entirely and costs a
+~35-50s fresh build for the first session per suite after a restart, which the warmer sidecar
+absorbs. §8 separately measured that `baseEngine` cloning gave **no** speedup on 6.6.3/6.9.7
+anyway, so even a fixed `copy()` is not on its own a reason to re-enable presets. Re-enabling
+should be driven by a measured win, not by the bug being closed.

--- a/docs/noecosystem-performance-analysis.md
+++ b/docs/noecosystem-performance-analysis.md
@@ -1,5 +1,11 @@
 # noEcosystem Performance Analysis
 
+> **Historical record, not current state.** This is a point-in-time comparison from
+> 2026-06-04. Every version, image tag and deployment detail below is as-of that date
+> (validator-wrapper `1.0.68`, a 2-replica StatefulSet, presets enabled). For the current
+> deployment see [`../VALIDATOR_OPTIMIZATION.md`](../VALIDATOR_OPTIMIZATION.md) §8-§10.
+> The `noEcosystem` finding itself still stands and is still applied.
+
 **Date:** 2026-06-04  
 **Compared:** au_core_v100 test suite, same FHIR server (smile.sparked-fhir.com/aucore)  
 **Prod session:** [cyCQ11nBExO](https://inferno.hl7.org.au/suites/au_core_v100/cyCQ11nBExO#au_core_v100) — `au_core_test_kit` 1.4.0, no `noEcosystem`  

--- a/docs/validator-benchmarking.md
+++ b/docs/validator-benchmarking.md
@@ -84,15 +84,26 @@ in au-ps-inferno's `bundle_module.rb` is behaviour-inert; pinning it to `preview
 - The validator runs as a **single-pod Deployment** (`replicas: 1`): one cache, no cross-pod
   thrash, automatic failover when the pod is replaced. (Earlier 2-replica setups thrashed —
   see `VALIDATOR_OPTIMIZATION.md` §8.)
-- **`baseEngine` does not help** — on the deployed core (6.6.3/6.9.7) cloning a preset's base
-  engine is ~as slow as a full build (~35–45s), so it can't cheaply re-warm. Ruled out.
+- **`baseEngine` does not help** — cloning a preset's base engine measured ~as slow as a full
+  build (~35–45s), so it can't cheaply re-warm. Ruled out. Measured on core 6.6.3/6.9.7; the
+  deployed core is now 6.9.12 (wrapper 1.0.81) and this has **not** been re-measured, but
+  presets are disabled outright (`VALIDATOR_OPTIMIZATION.md` §9) so the clone path is not in
+  use regardless.
 
 ## Keeping it warm
 
 - `SESSION_CACHE_DURATION=-1` holds the session warm while the pod lives.
-- The **warmer CronJob** (`templates/validator-warmer.cronjob.yaml`) runs one validation
-  through Inferno every ~30 min: re-warms the session after a restart (under the same id real
-  users hit) and the tx cache, and doubles as an end-to-end synthetic health check.
+- The **warmer runs as a `session-warmer` sidecar** in the validator pod
+  (`templates/configs/validator-warmer-configmap.yaml` + `files/warmer.py`). It warms once on
+  startup, then polls the co-located validator on `localhost:3500` and re-warms on an
+  unreachable→reachable transition, i.e. exactly when the validator restarted. It warms
+  **through Inferno**, so the session is built under the id Inferno actually reuses.
+
+  > This previously described a "warmer CronJob (`templates/validator-warmer.cronjob.yaml`)"
+  > running every ~30 min and doubling as a synthetic health check. That is wrong on every
+  > count as of #127: the file does not exist, there is no CronJob in any namespace (verified
+  > 2026-07-25), there is no timer, and it is explicitly **not** a health check. Sessions never
+  > time-expire, so warming is only needed after a restart. See `VALIDATOR_OPTIMIZATION.md` §8.
 - **Before a high-load event:** warm the **full** example set (not just the one warmer bundle)
   so the tx cache covers all the codes participants will use.
 

--- a/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
@@ -91,6 +91,14 @@ spec:
         # values.yaml and VALIDATOR_OPTIMIZATION.md §10.
         - name: VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD
           value: {{ .Values.validator.engineReloadThreshold | default 250000000 | quote }}
+        {{- if hasKey .Values.validator "terminologyClientUseCacheId" }}
+        # Wrapper 1.0.81+ only. Emitted ONLY when explicitly set, because the wrapper reads
+        # it as `getenv(...).uppercase() == "TRUE"` — an empty or absent-but-present value
+        # would evaluate to FALSE and silently flip behaviour, so there is no safe "unset"
+        # string to template. Omitting the key entirely leaves the wrapper's own default.
+        - name: TERMINOLOGY_CLIENT_USE_CACHE_ID
+          value: {{ .Values.validator.terminologyClientUseCacheId | quote }}
+        {{- end }}
         ports:
         - containerPort: 3500
         volumeMounts:

--- a/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
@@ -76,11 +76,21 @@ spec:
         # wrapper's 60-min expire-after-access default silently evict them (which forces
         # a ~50s cold engine rebuild on the first validation of a later run). See the
         # validator.sessionCache* notes in values.yaml. size is memory-bound — each
-        # cached engine is large and these pods run close to the 12Gi limit.
+        # cached engine is ~400Mi of live heap, so the LRU cap sets the heap floor.
         - name: SESSION_CACHE_DURATION
           value: {{ .Values.validator.sessionCacheDuration | default -1 | quote }}
         - name: SESSION_CACHE_SIZE
           value: {{ .Values.validator.sessionCacheSize | default 6 | quote }}
+        # Heap-pressure guard, in BYTES. The wrapper checks Runtime.freeMemory() against
+        # this on every request and, when under, discards the whole ValidationService —
+        # wiping every cached session — then System.gc()s and rebuilds. freeMemory() is
+        # free-within-COMMITTED heap, so it dips naturally just before any normal GC once
+        # the heap is right-sized. That makes this coupled to javaOpts: it must not be
+        # left at the 250MB wrapper default alongside a smaller -Xmx, or healthy GC
+        # behaviour wipes warm sessions every 5 min (the reload cooldown). See
+        # values.yaml and VALIDATOR_OPTIMIZATION.md §10.
+        - name: VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD
+          value: {{ .Values.validator.engineReloadThreshold | default 250000000 | quote }}
         ports:
         - containerPort: 3500
         volumeMounts:
@@ -93,11 +103,11 @@ spec:
         - name: validator-presets
           mountPath: /presets
           readOnly: true
-        # Defaults (values.yaml) sized for dev/prod: request is memory-driven (10Gi) onto
-        # 2-4 vCPU r-family nodes; cpu limit 3000m is a burst ceiling (validations are
-        # CPU-bound and starved the health endpoint at 2000m), request stays 1000m. Load
-        # test: one warm pod handles 10 concurrent at ~2.0/3 cores, mem flat ~9.5Gi. Preview
-        # overrides these much lower (see the inferno-previews ApplicationSet).
+        # Defaults (values.yaml) sized for dev/prod: request is memory-driven (6Gi, sized
+        # to the 5g heap per §10) onto 2-4 vCPU r-family nodes; cpu limit 3000m is a burst
+        # ceiling (validations are CPU-bound and starved the health endpoint at 2000m),
+        # request stays 1000m. Load test: one warm pod handles 10 concurrent at ~2.0/3
+        # cores. Preview overrides these much lower (see the inferno-previews ApplicationSet).
         resources:
           {{- toYaml .Values.validator.resources | nindent 10 }}
         startupProbe:

--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -14,21 +14,30 @@ validator:
   replicas: 1
   storageClassName: "gp3-encrypted"
   # Dev-only memory reclaim. Two independent knobs, both dev-only (prod keeps the
-  # base values.yaml settings). Heap (-Xmx8g) is left alone in both so a real heavy
-  # dev validation still has room.
+  # base values.yaml settings).
   #
-  # 1. requests.memory 10Gi to 6Gi (below): a scheduling/cost knob only. During the
-  #    Sparked event dev peaked 8.9Gi (07-01/02) then settled to a 2.7-4.5Gi baseline,
-  #    so the base 10Gi request over-reserves here. The (unchanged) 12Gi limit absorbs
-  #    the occasional warm-cache burst. Not applied to prod (prod peaked 9.4Gi).
+  # Heap is no longer "left alone": as of §10 the BASE javaOpts is -Xmx5g (was -Xmx8g),
+  # sized from 30 days of prod live-heap telemetry, and dev inherits it. That attacks
+  # the RSS problem knob 2 was working around at its source, because RSS parks at the
+  # -Xmx ceiling (G1 commits on demand, never uncommits). Keep both dev knobs for now
+  # and re-measure dev RSS after this rolls: if it settles well under the ~6Gi the 8Gi
+  # dev node needs, sessionCacheDuration can likely go back to -1 (permanent warmth, no
+  # ~50s post-idle rebuild) and this block shrinks to just the request override.
   #
-  # 2. sessionCache* (below): the actual-RSS knob, and the one that fixes the recurring
+  # 1. requests.memory to 6Gi (below): a scheduling/cost knob only. During the Sparked
+  #    event dev peaked 8.9Gi (07-01/02) then settled to a 2.7-4.5Gi baseline. Now equal
+  #    to the base request, so this is a no-op kept as an explicit floor. The earlier
+  #    "not applied to prod (prod peaked 9.4Gi)" rationale was reading RSS, which is
+  #    committed heap rather than live data — prod's live set is 2.09Gi (§10).
+  #
+  # 2. sessionCache* (below): an actual-RSS knob, and the one that fixed the recurring
   #    "Node Memory Saturation" page. requests.memory does NOT bound real memory, and
   #    that alert measures actual RAM (100 * (1 - MemAvailable/MemTotal) > 90), so the
   #    request cut alone never quieted it. With the base duration -1 (never expire) +
   #    size 8, each distinct validation context builds a large resident ValidationEngine
-  #    (~0.8-1.5Gi) held until the pod restarts, so dev RSS ratchets monotonically
-  #    (4.3 to 5.1 to 6.7Gi over 07-13) and parks at the top. On the 8Gi dev node that
+  #    (estimated ~0.8-1.5Gi here from RSS growth; prod's live-heap trace since §9 puts
+  #    it nearer ~400Mi, so this over-counted) held until the pod restarts, so dev RSS
+  #    ratchets monotonically (4.3 to 5.1 to 6.7Gi over 07-13) and parks at the top. On the 8Gi dev node that
   #    crosses the 90% line (RSS has to stay under ~6Gi). Dev runs on a cheap 8Gi node
   #    and idles between test sessions, so:
   #      - sessionCacheDuration: 30  re-enables idle expiry. Value is MINUTES

--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -13,13 +13,29 @@ redirectIngress:
 inferno:
   imageUrl: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0
   usesWrapper: true
-  # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.78 /
-  # core 6.9.7). 1.0.78 adds a ReentrantLock + cooldown around the heap-pressure engine
-  # reload that 1.0.68 lacked (1.0.68 rebuilt the whole ValidationService — wiping the
-  # session cache — on ANY request seeing free heap under the ~238MB default threshold,
-  # with no cooldown), and ships a newer org.hl7.fhir.core. Prod stays pinned (never
-  # :latest) so promotions are explicit; bump this tag to adopt a newer soaked version.
-  validatorImageUri: markiantorno/validator-wrapper:1.0.78
+  # Pinned to match the version dev has soaked on (dev tracks :latest, currently 1.0.81 /
+  # core 6.9.12). Prod stays pinned (never :latest) so promotions are explicit; bump this
+  # tag to adopt a newer soaked version.
+  #
+  # Retained from 1.0.78: the ReentrantLock + 5-min cooldown around the heap-pressure
+  # engine reload that 1.0.68 lacked (1.0.68 rebuilt the whole ValidationService — wiping
+  # the session cache — on ANY request seeing free heap under the ~238MB default
+  # threshold, with no cooldown). §10 now pins that threshold to 10MB outright.
+  #
+  # New in 1.0.79 to 1.0.81, and the reason for this bump: terminology caching. 1.0.79
+  # "use terminology server cacheing features" + core 6.9.11; 1.0.80 core 6.9.12; 1.0.81
+  # adds TERMINOLOGY_CLIENT_USE_CACHE_ID (default TRUE). The cold terminology cache is
+  # the measured concurrency limiter for this deployment (docs/validator-benchmarking.md:
+  # conc=10 on a large bundle is ~13s with a warm tx cache vs ~180s cold, while CPU sits
+  # at only ~1.7/3 cores), so this is the release range that targets the real bottleneck.
+  #
+  # CONFORMANCE NOTE: 6.9.7 to 6.9.12 is a validation-engine change and can legitimately
+  # alter validation results. Verified on the PR preview with a full AU Core v2.1.0-draft
+  # run before merging (see the PR's load-test comment). Presets remain empty (§9), so the
+  # base-engine clone path behind the profile-resolve desync is still not in play. Do NOT
+  # re-enable presets on the strength of this core bump without first re-checking whether
+  # CanonicalResourceManager.copy() now deep-copies listForId as well as listForUrl.
+  validatorImageUri: markiantorno/validator-wrapper:1.0.81
 
 autoscaling:
   enabled: true

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -19,7 +19,14 @@ inferno:
   imageUrl: "ghcr.io/hl7au/au-fhir-inferno:overridden-per-environment"
   terminologyServer: "https://tx.dev.hl7.org.au/fhir"
   externalValidatorUrl: null  # This can be overridden during chart deployment
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.78"
+  # Base default, inherited by preview environments (values-dev tracks :latest,
+  # values-prod pins explicitly). 1.0.81 brings org.hl7.fhir.core 6.9.12 and, more
+  # to the point, the terminology-cache work in 1.0.79 ("use terminology server
+  # cacheing features") and 1.0.81 (TERMINOLOGY_CLIENT_USE_CACHE_ID, default TRUE).
+  # docs/validator-benchmarking.md measured the cold terminology cache as THE
+  # concurrency limiter (conc=10 large bundle: ~13s tx-warm vs ~180s tx-cold, at
+  # only ~1.7/3 cores), so that is the line item worth chasing here.
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.81"
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -35,12 +35,16 @@ validator:
   #
   # duration < 0 disables time-based expiry (sessions kept until LRU-evicted). size is
   # the max number of resident engines (LRU). Each engine is large (loads ~20+ IG/tx
-  # packages), so size is memory-bound: the pod sits ~9.4Gi/12Gi at idle, so raise size
-  # only with headroom and watch RSS. The shared validator boot-warms one session per
-  # registered suite — dev warms ~5 distinct contexts (AU PS preview, AU Core
-  # 1.0.0-ballot/1.0.0/2.0.0, smart-app-launch) — so size must clear that working set
-  # plus headroom, else LRU (now the only eviction path) re-introduces cold starts.
-  # Each resident engine is a full build (~80-150Mi); 8 covers the 5 contexts + spare.
+  # packages), so size is memory-bound. Judge that against LIVE heap, not RSS: RSS
+  # tracks the -Xmx ceiling because G1 never uncommits (§10). The shared validator
+  # boot-warms one session per registered suite — prod warms ~5 distinct contexts (AU PS
+  # preview, AU Core 1.0.0-ballot/1.0.0/2.0.0, smart-app-launch) — so size must clear
+  # that working set plus headroom, else LRU (now the only eviction path) re-introduces
+  # cold starts. Prod's flat 2021Mi live Old Gen across those ~5 contexts puts a resident
+  # engine at ~400Mi, so 8 slots is a ~3.2Gi worst case; that is what -Xmx5g is sized
+  # against. (An earlier ~80-150Mi per-engine estimate here was inferred from RSS growth
+  # and undercounted; the ~0.8-1.5Gi figure in values-dev.yaml overcounted for the same
+  # reason. Both predate the post-§9 live-heap measurement.)
   sessionCacheDuration: -1
   sessionCacheSize: 8
   # Singleton: the session cache is per-pod and in-memory, so the validator runs as a
@@ -51,15 +55,44 @@ validator:
   # nodes so reschedule is reliable. Raising this above 1 reintroduces cross-pod thrash.
   replicas: 1
   # JVM heap. Must fit the loaded IG/terminology context; preview overrides it lower.
-  javaOpts: "-Xmx8g"
-  # Pod resources. Defaults sized for dev/prod (load-tested: one warm pod serves 10
-  # concurrent at ~2.0/3 cores, ~9.5Gi mem). Preview overrides these much lower.
+  #
+  # Sized from 30 days of prod telemetry (VALIDATOR_OPTIMIZATION.md §10), not from RSS.
+  # RSS is a poor proxy here: G1 commits on demand and never uncommits, so the pod parks
+  # at the -Xmx ceiling regardless of how much is live. Measured on prod since the §9 fix
+  # settled (07-07 onward): live heap after GC is flat at 2028-2091Mi for 18 straight
+  # days, non-heap ~208Mi, GC pause fraction ~0, zero OOMKills. 5g is ~2.4x the steady
+  # live set and ~1.5x the all-8-slots worst case (~3.2Gi).
+  #
+  # MUST be changed together with engineReloadThreshold below — see the warning there.
+  javaOpts: "-Xmx5g"
+  # Wrapper heap-pressure guard (env: VALIDATION_SERVICE_ENGINE_RELOAD_THRESHOLD, BYTES,
+  # wrapper default 250000000). ValidationServiceFactoryImpl.getValidationService() checks
+  # Runtime.freeMemory() < threshold on EVERY request and, if so, throws away the entire
+  # ValidationService — wiping every cached session — then System.gc()s and rebuilds.
+  #
+  # The trap: freeMemory() is free-within-COMMITTED heap, so it is naturally near zero
+  # just before any normal GC on a right-sized heap. At -Xmx8g the sawtooth floor was
+  # ~850Mi free, always above the 250MB default, which is the only reason this never
+  # fired in prod (confirmed: zero reload log lines in 30 days). Cutting the heap to 5g
+  # without also cutting this would make it fire routinely on healthy GC behaviour,
+  # wiping warm sessions and re-introducing the ~50s cold rebuild every 5 min (the
+  # RELOAD_COOLDOWN_MS floor). Set to 10MB so it stays a genuine last-resort guard and
+  # cannot trip on ordinary allocation. Safe because the 30-day Old Gen trace is flat
+  # (2021Mi, no leak) — there is no drift for this valve to relieve, and a true OOM is
+  # already handled by the container limit plus restart plus the warmer sidecar.
+  # Quoted deliberately: unquoted, Helm/YAML coerces this to a float and renders it as
+  # "1e+07", which the wrapper's HOCON config parser does not read as a byte count.
+  engineReloadThreshold: "10000000"
+  # Pod resources. Sized to the 5g heap: 5g heap + ~208Mi non-heap + ~500Mi native/JIT/
+  # threads lands ~5.8Gi, so 6Gi request / 8Gi limit keeps the same headroom ratio the
+  # 10Gi/12Gi pair had against -Xmx8g. Load-tested: one warm pod serves 10 concurrent at
+  # ~2.0/3 cores. Preview overrides these much lower.
   resources:
     requests:
-      memory: "10Gi"
+      memory: "6Gi"
       cpu: "1000m"
     limits:
-      memory: "12Gi"
+      memory: "8Gi"
       cpu: "3000m"
 
 # NOTE: validator autoscaling (HPA) was removed. It does not fit this validator: each

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -24,7 +24,7 @@ inferno:
   # the 1.0.81 preview on perf/validator-heap-rightsize. Every other value on this
   # branch is byte-identical to that one, so the wrapper version is the ONLY variable.
   # Delete this branch once the comparison is recorded on #156.
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.78"
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.81"
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -19,14 +19,12 @@ inferno:
   imageUrl: "ghcr.io/hl7au/au-fhir-inferno:overridden-per-environment"
   terminologyServer: "https://tx.dev.hl7.org.au/fhir"
   externalValidatorUrl: null  # This can be overridden during chart deployment
-  # Base default, inherited by preview environments (values-dev tracks :latest,
-  # values-prod pins explicitly). 1.0.81 brings org.hl7.fhir.core 6.9.12 and, more
-  # to the point, the terminology-cache work in 1.0.79 ("use terminology server
-  # cacheing features") and 1.0.81 (TERMINOLOGY_CLIENT_USE_CACHE_ID, default TRUE).
-  # docs/validator-benchmarking.md measured the cold terminology cache as THE
-  # concurrency limiter (conc=10 large bundle: ~13s tx-warm vs ~180s tx-cold, at
-  # only ~1.7/3 cores), so that is the line item worth chasing here.
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.81"
+  # ############# A/B CONTROL BRANCH — DO NOT MERGE #############
+  # Held at 1.0.78 so this preview is a same-cluster, same-wall-clock control against
+  # the 1.0.81 preview on perf/validator-heap-rightsize. Every other value on this
+  # branch is byte-identical to that one, so the wrapper version is the ONLY variable.
+  # Delete this branch once the comparison is recorded on #156.
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.78"
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -90,6 +90,20 @@ validator:
   # Quoted deliberately: unquoted, Helm/YAML coerces this to a float and renders it as
   # "1e+07", which the wrapper's HOCON config parser does not read as a byte count.
   engineReloadThreshold: "10000000"
+  # Wrapper 1.0.81+ (TERMINOLOGY_CLIENT_USE_CACHE_ID, wrapper default TRUE). Controls
+  # whether the terminology client sends a cache id to the tx server.
+  #
+  # UNDER TEST — not a settled default. Measured on the PR preview at conc=10 (23KB AU PS
+  # bundle, one warm session, 6 runs): 1.0.81 sits at ~3.1s (2.71-3.66) against a single
+  # 1.0.78 baseline sample of 2.23s. Per-run `min` stays ~0.7-1.6s while p50/max sit at
+  # ~2.7-3.7s, i.e. one request completes promptly and the rest queue — a serialisation
+  # signature, which is what a shared cache-id negotiation would produce. GC is ruled out
+  # (4.15s total GC over 3h, zero full GCs, heap never passed 3292Mi of a 5g ceiling).
+  #
+  # Set to "false" here to A/B it against the wrapper default. Comment the key out entirely
+  # to restore the wrapper's behaviour — do NOT set it to "" (see the template: an empty
+  # value reads as FALSE, not as unset).
+  terminologyClientUseCacheId: "false"
   # Pod resources. Sized to the 5g heap: 5g heap + ~208Mi non-heap + ~500Mi native/JIT/
   # threads lands ~5.8Gi, so 6Gi request / 8Gi limit keeps the same headroom ratio the
   # 10Gi/12Gi pair had against -Xmx8g. Load-tested: one warm pod serves 10 concurrent at

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -24,7 +24,7 @@ inferno:
   # the 1.0.81 preview on perf/validator-heap-rightsize. Every other value on this
   # branch is byte-identical to that one, so the wrapper version is the ONLY variable.
   # Delete this branch once the comparison is recorded on #156.
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.81"
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.79"
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -93,17 +93,26 @@ validator:
   # Wrapper 1.0.81+ (TERMINOLOGY_CLIENT_USE_CACHE_ID, wrapper default TRUE). Controls
   # whether the terminology client sends a cache id to the tx server.
   #
-  # UNDER TEST — not a settled default. Measured on the PR preview at conc=10 (23KB AU PS
-  # bundle, one warm session, 6 runs): 1.0.81 sits at ~3.1s (2.71-3.66) against a single
-  # 1.0.78 baseline sample of 2.23s. Per-run `min` stays ~0.7-1.6s while p50/max sit at
-  # ~2.7-3.7s, i.e. one request completes promptly and the rest queue — a serialisation
-  # signature, which is what a shared cache-id negotiation would produce. GC is ruled out
-  # (4.15s total GC over 3h, zero full GCs, heap never passed 3292Mi of a 5g ceiling).
+  # DELIBERATELY UNSET — leave it that way. The key is intentionally absent so the wrapper
+  # default (TRUE) applies; the template only emits the env var when the key is present.
+  # Do NOT "disable" this by setting it to "" — the wrapper reads it as
+  # getenv(...).uppercase() == "TRUE", so an empty string means FALSE, not unset.
   #
-  # Set to "false" here to A/B it against the wrapper default. Comment the key out entirely
-  # to restore the wrapper's behaviour — do NOT set it to "" (see the template: an empty
-  # value reads as FALSE, not as unset).
-  terminologyClientUseCacheId: "false"
+  # A/B measured on the PR preview (same pod spec, same -Xmx5g, wrapper 1.0.81, 23KB AU PS
+  # bundle, one warm session, 6 runs at conc=10):
+  #
+  #   useCacheId=true  (default)   conc=1 0.67-0.86s   conc=10 ~3.10s (2.71-3.66)
+  #   useCacheId=false             conc=1 1.12-1.43s   conc=10 ~4.62s (4.06-6.00)
+  #
+  # Turning it OFF is ~40% SLOWER at both concurrency levels, so the default is the right
+  # setting and this was tested and rejected, not merely left alone. Caveat on the numbers:
+  # the false-run measured a pod whose terminology cache had been populated while the flag
+  # was true, so some of that penalty may be cache mismatch rather than steady-state cost.
+  # The direction is consistent enough that inverting the default is not worth pursuing.
+  #
+  # The knob is kept for the escape hatch: if a future wrapper or tx-server change makes
+  # cache ids misbehave, this can be pinned without editing the deployment by hand.
+  # terminologyClientUseCacheId: "false"
   # Pod resources. Sized to the 5g heap: 5g heap + ~208Mi non-heap + ~500Mi native/JIT/
   # threads lands ~5.8Gi, so 6Gi request / 8Gi limit keeps the same headroom ratio the
   # 10Gi/12Gi pair had against -Xmx8g. Load-tested: one warm pod serves 10 concurrent at


### PR DESCRIPTION
**Throwaway branch. Do not merge. Delete once the comparison is recorded on #156.**

## Purpose

Stands up a preview environment identical to #156 except pinned to **validator-wrapper 1.0.78**, so 1.0.78 and 1.0.81 can be measured **side by side, in the same cluster, at the same wall-clock time, against the same terminology server**.

## Why this is needed

The earlier comparison was not controlled. A **single** 1.0.78 sample, taken on a pod with different terminology-cache history, against six 1.0.81 samples taken later:

```
1.0.78 / -Xmx6g   conc=10   2.23s          (n=1)
1.0.81 / -Xmx5g   conc=10   ~3.10s         (n=6, range 2.71-3.66)
```

That looked like a ~40% regression, and I reported it as one. The `TERMINOLOGY_CLIENT_USE_CACHE_ID` A/B then **disproved** the only mechanism proposed for it — disabling the flag made things *worse* (~4.62s), not better — which leaves under-sampling as the most likely explanation. Since the 1.0.81 range alone spans 2.71-3.66, a single 2.23s draw is well within the plausible spread of the same distribution.

Rather than leave an unresolved performance question hanging over the wrapper bump, this measures it properly.

## Control

Byte-identical to `perf/validator-heap-rightsize` apart from the image tag:

```diff
-  validatorImageUri: "markiantorno/validator-wrapper:1.0.81"
+  validatorImageUri: "markiantorno/validator-wrapper:1.0.78"
```

Same `-Xmx5g`, same `engineReloadThreshold: 10000000`, same `TERMINOLOGY_CLIENT_USE_CACHE_ID` (unset → wrapper default), same resources. **Wrapper version is the only variable.**

## Method

Both previews get fresh PVCs, so:

1. **Warm the package + terminology caches** on both with one validation each.
2. **Restart both validator pods.** PVCs survive, the in-memory session does not — this reproduces the *production* cold start (warm disk cache, cold session engine), not the fresh-volume case.
3. **Cold-start measurement**: time the first validation after restart on each.
4. **conc=10**: warm a session on each, then run repeated conc=10 batches **interleaved** (A, B, A, B, …) rather than all-A-then-all-B, so drift in the shared terminology server affects both arms equally.

Results will be posted to #156.