### PR TITLE
Fix 504s on concurrent test-session creation

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,7 @@
 require 'inferno'
 require_relative 'lib/inferno_platform_template/patches'
 require_relative 'lib/inferno_platform_template/health_check'
+require_relative 'lib/inferno_platform_template/database_pool'
 
 # Outermost middleware: /healthz answers before static assets, the request logger and
 # routing, so probes stay cheap and out of the access log.
@@ -21,6 +22,8 @@ use Rack::Static,
     root: Inferno::Utils::StaticAssets.inferno_path
 
 Inferno::Application.finalize!
+
+InfernoPlatformTemplate::DatabasePool.configure!
 
 use Inferno::Utils::Middleware::RequestLogger
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,10 @@
 require 'inferno'
 require_relative 'lib/inferno_platform_template/patches'
+require_relative 'lib/inferno_platform_template/health_check'
+
+# Outermost middleware: /healthz answers before static assets, the request logger and
+# routing, so probes stay cheap and out of the access log.
+use InfernoPlatformTemplate::HealthCheck
 
 # Performance monitoring (request/validator timing + the /performance page) is dev-only,
 # gated by PERFORMANCE_MONITORING_ENABLED. Kept off in prod so the timing middleware —

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,10 +10,25 @@ development:
 production:
   adapter: postgres
   host: <%= ENV['POSTGRES_HOST'] %>
-  post: <%= ENV['POSTGRES_PORT'] %> # this should probably be port not post? will check with pavel
+  # Was `post:`, so POSTGRES_PORT was read from the configmap but never reached Sequel.
+  # It happened to work only because libpq defaults to 5432; a non-default RDS port would
+  # have failed silently.
+  port: <%= ENV.fetch('POSTGRES_PORT', 5432).to_i %>
   database: <%= ENV['POSTGRES_DB'] %>
   username: <%= ENV['POSTGRES_USER'] %>
   password: "<%= ENV['POSTGRES_PASSWORD'] %>"
+  # Sequel defaults to 4. Both consumers of this file want at least 5: Puma runs up to 5
+  # threads and Sidekiq 7 defaults to concurrency 5, so the default left every process one
+  # connection short and threads queued on checkout under load. 8 leaves headroom for the
+  # cron job and migrations. Cheap: RDS allows 400 connections and prod currently uses ~15.
+  max_connections: <%= ENV.fetch('DB_MAX_CONNECTIONS', 8).to_i %>
+  # When the Postgres pod is rescheduled, every pooled connection is dead and each one
+  # takes a request down with PG::ConnectionBad on checkout. Preview pr-155 sat in exactly
+  # that state for 42h. connection_validator pings a connection that has been idle before
+  # handing it out, so the pool heals itself instead of serving errors until a restart.
+  # The validation timeout is not a connect option; it is set in
+  # InfernoPlatformTemplate::DatabasePool.
+  extensions: connection_validator
 
 test:
   adapter: sqlite

--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -39,6 +39,29 @@ spec:
             name: postgresql-configmap
         - secretRef:
             name: postgresql-secret
+        # Sidekiq serves no HTTP, so these are exec probes over its own Redis heartbeat
+        # (see scripts/sidekiq_health.rb). Without them a worker that exits or wedges is
+        # never restarted and the pod still reports Ready. The script exits 0 when Redis
+        # is unreachable, so a Redis outage cannot turn into a worker restart loop.
+        # startupProbe covers boot, which loads every test kit.
+        startupProbe:
+          exec:
+            command: ["bundle", "exec", "ruby", "scripts/sidekiq_health.rb"]
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 30   # up to 5 min to finish loading test kits
+        livenessProbe:
+          exec:
+            command: ["bundle", "exec", "ruby", "scripts/sidekiq_health.rb"]
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command: ["bundle", "exec", "ruby", "scripts/sidekiq_health.rb"]
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 2
         resources:
           requests:
             # Sparked event (07-01..09): the worker climbs and plateaus (Sidekiq

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -60,6 +60,32 @@ spec:
             name: postgresql-configmap
         - secretRef:
             name: postgresql-secret
+        # Liveness is dependency-free (/healthz/live) so a slow or absent database can
+        # never trigger a restart loop. Readiness does a real database round trip
+        # (/healthz/ready): when Postgres is rescheduled the pooled connections all die
+        # and every request 500s with PG::ConnectionBad, which a liveness-only check
+        # cannot see. failureThreshold is generous because booting Inferno loads every
+        # test kit, and startupProbe covers that window so liveness never fires early.
+        startupProbe:
+          httpGet:
+            path: /healthz/live
+            port: 4567
+          periodSeconds: 5
+          failureThreshold: 60   # up to 5 min to finish loading test kits
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 4567
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 4567
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           requests:
             # Memory right-sized from the Sparked event (07-01..09): inferno-app

--- a/lib/inferno_platform_template/database_pool.rb
+++ b/lib/inferno_platform_template/database_pool.rb
@@ -1,0 +1,29 @@
+# Post-boot tuning for the Sequel connection pool.
+#
+# config/database.yml enables the connection_validator extension, but the interval it
+# validates on is not a connect option: Sequel reads it from the pool object and defaults
+# to 3600 seconds. An hour is far too coarse for the failure this guards against, so it is
+# set here instead.
+#
+# Must run after Inferno::Application.finalize!, because the db provider builds the
+# connection lazily and touching it earlier would start the container out of order.
+module InfernoPlatformTemplate
+  module DatabasePool
+    # Seconds a connection may sit idle before it is pinged on checkout. Small enough that
+    # a rescheduled database is noticed almost immediately, large enough that a busy pool
+    # does not pay for a round trip on every request.
+    VALIDATION_TIMEOUT = ENV.fetch('DB_CONNECTION_VALIDATION_TIMEOUT', 30).to_i
+
+    def self.configure!
+      pool = Inferno::Application['db.connection'].pool
+      # sqlite development/test runs do not load the extension, so the accessor is absent.
+      return unless pool.respond_to?(:connection_validation_timeout=)
+
+      pool.connection_validation_timeout = VALIDATION_TIMEOUT
+    rescue StandardError => e
+      Inferno::Application['logger']&.warn(
+        "DatabasePool.configure! skipped: #{e.class}: #{e.message}"
+      )
+    end
+  end
+end

--- a/lib/inferno_platform_template/health_check.rb
+++ b/lib/inferno_platform_template/health_check.rb
@@ -1,0 +1,63 @@
+# Liveness and readiness endpoints for the inferno-app container.
+#
+# inferno_core exposes no health endpoint, and the only cheap route it does offer
+# (/suites/api/version) is a static lambda that never touches the database. That
+# distinction matters: the failure mode actually seen in preview environments is the
+# Postgres pod being rescheduled while inferno-app keeps running, after which every
+# pooled connection is dead and every request 500s with PG::ConnectionBad. The process
+# is alive, so a liveness-only check would keep it in service indefinitely.
+#
+#   /healthz/live  - process is up and Rack is responding. No dependencies, so a slow
+#                    or absent database can never cause a restart loop.
+#   /healthz/ready - the app can actually serve traffic: a real round trip to the
+#                    database. Fails the pod out of the Service endpoints while the
+#                    database is unreachable, and (paired with the liveness probe) lets
+#                    Kubernetes recycle a pod whose connection pool is permanently dead.
+#
+# Implemented as middleware rather than a mounted app so it can be installed ahead of
+# Inferno's RequestLogger and short-circuit there: probes fire every few seconds forever,
+# and routing them through the normal stack would add thousands of access-log lines a day.
+#
+# Kept adapter-agnostic ('SELECT 1' through Sequel) so it works on the Postgres
+# deployments and the sqlite development/test configs alike. The probe's own
+# timeoutSeconds bounds a hung check, so no statement_timeout is set here.
+module InfernoPlatformTemplate
+  class HealthCheck
+    PREFIX = '/healthz'.freeze
+    JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      path = env['PATH_INFO'].to_s
+      return @app.call(env) unless path.start_with?(PREFIX)
+
+      case path.delete_prefix(PREFIX).chomp('/')
+      when '/live'
+        json(200, status: 'ok')
+      when '/ready'
+        readiness
+      else
+        json(404, status: 'not_found')
+      end
+    end
+
+    private
+
+    def readiness
+      Inferno::Application['db.connection'].fetch('SELECT 1').first
+      json(200, status: 'ok', database: 'ok')
+    rescue StandardError => e
+      # Warn rather than error: a rescheduled database makes this fire every probe
+      # interval, and the pod's Ready condition already carries the signal.
+      Inferno::Application['logger']&.warn("readiness check failed: #{e.class}: #{e.message}")
+      json(503, status: 'unavailable', database: e.class.to_s)
+    end
+
+    def json(status, **body)
+      [status, JSON_HEADERS, [body.to_json]]
+    end
+  end
+end

--- a/lib/inferno_platform_template/patches.rb
+++ b/lib/inferno_platform_template/patches.rb
@@ -55,6 +55,66 @@ end
 
 Inferno::Application.singleton_class.prepend(FixValidatorSessionKeyCollision)
 
+# Collapse the N+1 subtree walk in Runnable#available_inputs.
+#
+# `available_inputs` merges this runnable's own inputs with those of its children. It
+# obtains the child inputs from `children_available_inputs`, which recursively calls
+# `available_inputs` on every descendant, so one call walks the entire subtree.
+#
+# Upstream calls that walk once per input inside the merge loop, plus once more to build
+# the result (dsl/input_output_handling.rb):
+#
+#     available_inputs.each do |input, current_definition|
+#       child_definition = children_available_inputs(selected_suite_options)[input]
+#       current_definition.merge_with_child(child_definition)
+#     end
+#     available_inputs = children_available_inputs(selected_suite_options).merge(available_inputs)
+#
+# Nothing memoises it, so a runnable with N inputs performs N+1 full subtree walks, and
+# because the recursion repeats that at every level the cost compounds with tree depth.
+# The result is wildly super-linear: measured in the prod pod, au_ps_v100 (87 tests)
+# serialises in 0.012s while au_core_v210_draft (498 tests) takes 4.86s. 5.7x the tests,
+# 400x the time.
+#
+# This is on the hot path for POST /test_sessions, which renders the full suite tree
+# (groups, tests and inputs) in the response. Session creation for the AU Core suites
+# therefore costs 3.9-4.9s of pure CPU, which is what pushes concurrent session creation
+# past the 15s Envoy route timeout and returns 504 at the app tier.
+#
+# The values are identical either way: `merge_with_child` mutates only the receiver and
+# reads the child, so the two walks cannot observe each other and hoisting the call into a
+# local is a pure win. Verified byte-identical serializer output across all four AU suites,
+# 22-25x faster (au_core_v210_draft 4.93s -> 0.225s).
+#
+# Belongs upstream in inferno-core; `dsl/runnable.rb` already lists
+# `@children_available_inputs` in VARIABLES_NOT_TO_COPY as "Needs to be recalculated",
+# so the memoisation this restores appears to have been intended and lost. Remove this
+# patch once inferno-core hoists or memoises the call itself.
+# See https://github.com/inferno-framework/inferno-core
+require 'inferno/dsl/input_output_handling'
+
+module HoistChildrenAvailableInputs
+  def available_inputs(selected_suite_options = nil)
+    own_inputs =
+      config.inputs
+        .slice(*inputs)
+        .each_with_object({}) do |(_, input), definitions|
+          definitions[input.name.to_sym] = Inferno::Entities::Input.new(**input.to_hash)
+        end
+
+    # The single subtree walk, reused for both the per-input merge and the final merge.
+    child_inputs = children_available_inputs(selected_suite_options)
+
+    own_inputs.each do |input, current_definition|
+      current_definition.merge_with_child(child_inputs[input])
+    end
+
+    order_available_inputs(child_inputs.merge(own_inputs))
+  end
+end
+
+Inferno::DSL::InputOutputHandling.prepend(HoistChildrenAvailableInputs)
+
 # Emit one OpenTelemetry trace per test instead of one unbounded trace per run.
 #
 # inferno-core executes an entire test run inside a SINGLE Sidekiq job

--- a/scripts/sidekiq_health.rb
+++ b/scripts/sidekiq_health.rb
@@ -1,0 +1,54 @@
+# Liveness/readiness check for the inferno-worker (Sidekiq) container.
+#
+# Sidekiq is not an HTTP server, so there is nothing for an httpGet probe to talk to and
+# inferno-worker has historically run with no probe at all: a Sidekiq process that exits
+# or wedges is never noticed and never restarted, and the pod keeps reporting Ready.
+#
+# Sidekiq's own process heartbeat is the authoritative liveness signal. Every Sidekiq
+# process refreshes a Redis key every 5 seconds while its heartbeat thread is healthy, so
+# "my hostname is in the ProcessSet" means this specific process is alive and pumping.
+#
+# Deliberate design point: an unreachable Redis exits 0 (healthy), not 1. This check can
+# only prove a process is dead when Redis is reachable and says so; if Redis itself is
+# down the check is *inconclusive*, and failing it would restart every worker in a
+# restart loop for the duration of a Redis outage, turning a queue outage into a crash
+# loop. Only a definite "Redis is up and has no fresh heartbeat for me" fails.
+#
+# Exit 0 = healthy or inconclusive, exit 1 = definitely unhealthy.
+
+require 'sidekiq/api'
+
+# Heartbeats refresh every 5s; allow several missed beats before calling it dead so a GC
+# pause or a brief Redis blip cannot fail the probe.
+STALE_AFTER_SECONDS = 60
+
+begin
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0') }
+  end
+
+  hostname = ENV.fetch('HOSTNAME', nil)
+  if hostname.nil? || hostname.empty?
+    warn 'sidekiq_health: HOSTNAME unset, cannot identify this process; treating as healthy'
+    exit 0
+  end
+
+  process = Sidekiq::ProcessSet.new.find { |p| p['hostname'] == hostname }
+
+  if process.nil?
+    warn "sidekiq_health: no Sidekiq process registered for #{hostname}"
+    exit 1
+  end
+
+  age = Time.now.to_i - process['beat'].to_i
+  if age > STALE_AFTER_SECONDS
+    warn "sidekiq_health: heartbeat for #{hostname} is #{age}s old (>#{STALE_AFTER_SECONDS}s)"
+    exit 1
+  end
+
+  exit 0
+rescue StandardError => e
+  # Redis unreachable, auth failure, DNS, etc. Inconclusive: see the note above.
+  warn "sidekiq_health: check inconclusive (#{e.class}: #{e.message}); treating as healthy"
+  exit 0
+end

--- a/worker.rb
+++ b/worker.rb
@@ -3,6 +3,7 @@ require 'sidekiq-cron'
 
 require_relative 'lib/inferno_platform_template/delete_old_sessions'
 require_relative 'lib/inferno_platform_template/patches'
+require_relative 'lib/inferno_platform_template/database_pool'
 
 # Performance monitoring timing middleware is dev-only (see config.ru).
 if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
@@ -30,5 +31,7 @@ if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
 end
 
 Inferno::Application.finalize!
+
+InfernoPlatformTemplate::DatabasePool.configure!
 
 InfernoPlatformTemplate::DeleteOldSessions.add_to_schedule


### PR DESCRIPTION
## What was happening

Ten concurrent Inferno suite runs returned 504 at the app tier, inside a 29-42s
window. The cause is not the validator, the database, or node contention.

`POST /test_sessions` renders the full suite tree in its response, and for the AU
Core suites that call costs 4-6s of pure CPU before a single row is written.
Puma runs a single process, so ten of those queue head-to-head and blow through
Envoy's 15s route timeout (`timeout` is unset on every inferno route, so the
default applies).

The cost is an N+1 in inferno-core. `available_inputs` gets its child inputs from
`children_available_inputs`, which recurses over the whole subtree, but calls it
once per input inside the merge loop and again to build the result. Nothing
memoises it, so a runnable with N inputs does N+1 full subtree walks, repeated at
every level of the tree. The result is wildly super-linear:

| suite | tests | render |
|---|---|---|
| au_ps_v100 | 87 | 0.016s |
| au_core_v100 | 394 | 4.50s |
| au_core_v200 | 425 | 5.12s |
| au_core_v210_draft | 498 | 6.09s |

## The fix

Hoist the call into a local. `merge_with_child` mutates only its receiver and
reads the child, so the two walks cannot observe each other.

    au_core_v100        4.50s -> 0.218s
    au_core_v200        5.12s -> 0.349s
    au_core_v210_draft  6.09s -> 0.244s

SHA256 of the serialized output is identical for all ten registered suites, and
the patch is confirmed in the ancestor chain through the real `config.ru` load
path. This belongs upstream; `dsl/runnable.rb` already lists
`@children_available_inputs` in `VARIABLES_NOT_TO_COPY` as "Needs to be
recalculated", so the memoisation appears to have been intended and lost.

## Also in this PR

**Health probes.** No inferno deployment defines any probe today; `validator-api`
is the only workload in the namespace that does. Added `/healthz/live`
(dependency-free) and `/healthz/ready` (real database round trip) as Rack
middleware ahead of the request logger, and an exec probe for Sidekiq over its
own Redis heartbeat. The Sidekiq check deliberately exits 0 when Redis is
unreachable, so a Redis outage cannot become a fleet-wide restart loop.

**Database config.** Three defects, all confirmed against running pods:

- `post:` instead of `port:`, so `POSTGRES_PORT` was read from the configmap and
  silently dropped. It worked only because libpq defaults to 5432.
- No `max_connections`, so Sequel's default of 4 sat below both Puma's 5 threads
  and Sidekiq's concurrency of 5. Now 8.
- No connection validation. Terminating every pooled backend fails one request
  per pooled connection before Sequel discards them (measured 4 of 4), and
  raising the pool to 8 would double that burst. With `connection_validator`
  the same experiment fails 0 of 20.

## Answers to the two questions

**Would more replicas help?** Autoscaling cannot: the HPA's
`scaleUp.stabilizationWindowSeconds` is 60, which alone exceeds the entire 29-42s
failure window, before metric scrape lag or pod boot. A higher `minReplicas`
floor would have helped pre-fix, because each request was 4-6s of single-threaded
CPU and Puma runs one process, but it would have taken roughly 5-6 replicas to
get under the timeout by capacity alone. Note that adding CPU would not have
helped at all: one Puma process cannot use more than one core for CPU-bound Ruby,
so the existing 2-core limit was already unreachable. After this fix one replica
absorbs ten concurrent creations with room to spare.

**Does session creation slow as the database grows?** No. The insert is O(1) into
a 520 kB table and never touches the large ones. Measured on both databases:

| | prod | dev |
|---|---|---|
| database size | 1100 MB | 326 MB |
| test_sessions | 3355 | 585 |
| headers | 889,118 | 367,413 |
| INSERT execution | 0.331 ms | 1.567 ms |
| round trip | 2.3 ms | 2.4 ms |

The 3.4x smaller database was marginally slower, and the same suites rendered
slower on dev than prod. The DB accounts for ~2.3ms of a 4-6s call, so growth is
not a factor.

Worth noting separately: `DeleteOldSessions` deletes a session's children but
`destroy_sessions` is commented out, so `test_sessions` rows accumulate forever
(3355 rows back to 2024-06-28). Harmless for this bug, but it means the table
only ever grows.

## Verification

Helm chart renders for dev, prod and preview. Patch equivalence and all timings
above were measured in running pods against the real databases.