### PR TITLE
Promote prod -> v1.0.2

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:1a4cccf75c854fad481d5d42aee28bc181cf5b3d
   usesWrapper: true
   # HELD AT 1.0.78. Prod stays pinned (never :latest) so promotions are explicit, but
   # this pin is now a deliberate hold rather than a lag: do not advance it without
@@ -39,7 +39,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:1a4cccf75c854fad481d5d42aee28bc181cf5b3d-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `213f6c8` → `1a4cccf` — staging already runs this exact artifact.

## Release version
Proposed: **v1.0.2** (patch bump of `v1.0.1`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`213f6c8`)
- chore: update AU PS test kit to version 0.2.0 and adjust dependencies (#151)
- chore: update AU PS test kit version to 0.2.1 in Gemfile and documentation (#153)
- perf(validator): right-size JVM heap from live-heap telemetry, pin reload guard (#156)
- Fix 504s on concurrent test-session creation (#159)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/213f6c898b0b059a86a477f68f2248b926bea4d0...1a4cccf75c854fad481d5d42aee28bc181cf5b3d

- app:   `ghcr.io/hl7au/au-fhir-inferno:1a4cccf75c854fad481d5d42aee28bc181cf5b3d`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:1a4cccf75c854fad481d5d42aee28bc181cf5b3d-nginx`
