### PR TITLE
Gate health probes on the environment's image supporting them

### DIFF
--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -39,6 +39,12 @@ spec:
             name: postgresql-configmap
         - secretRef:
             name: postgresql-secret
+        {{- if .Values.healthProbes.enabled }}
+        # Gated on healthProbes.enabled because scripts/sidekiq_health.rb ships in the
+        # application image, and inferno.imageUrl is pinned per environment and promoted
+        # separately from this chart. An environment on an image without that script fails
+        # every new pod's startup probe and wedges the rollout. See values.yaml.
+        #
         # Sidekiq serves no HTTP, so these are exec probes over its own Redis heartbeat
         # (see scripts/sidekiq_health.rb). Without them a worker that exits or wedges is
         # never restarted and the pod still reports Ready. The script exits 0 when Redis
@@ -62,6 +68,7 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 15
           failureThreshold: 2
+        {{- end }}
         resources:
           requests:
             # Sparked event (07-01..09): the worker climbs and plateaus (Sidekiq

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -60,6 +60,12 @@ spec:
             name: postgresql-configmap
         - secretRef:
             name: postgresql-secret
+        {{- if .Values.healthProbes.enabled }}
+        # Gated on healthProbes.enabled because these endpoints ship in the application
+        # image, and inferno.imageUrl is pinned per environment and promoted separately
+        # from this chart. An environment on an image without them fails every new pod's
+        # startup probe and wedges the rollout. See values.yaml.
+        #
         # Liveness is dependency-free (/healthz/live) so a slow or absent database can
         # never trigger a restart loop. Readiness does a real database round trip
         # (/healthz/ready): when Postgres is rescheduled the pooled connections all die
@@ -86,6 +92,7 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
+        {{- end }}
         resources:
           requests:
             # Memory right-sized from the Sparked event (07-01..09): inferno-app

--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -67,3 +67,9 @@ podDisruptionBudgets:
   - app: inferno-worker
   - app: nginx-app
   - app: redirect-nginx
+
+healthProbes:
+  # Prod pins inferno.imageUrl to a promoted SHA that predates the /healthz endpoints and
+  # scripts/sidekiq_health.rb, so probing them here fails every new pod. Flip this to true
+  # in the same PR that promotes prod to an image containing them.
+  enabled: false

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -267,3 +267,15 @@ postgresql:
 # Empty by default: dev and preview run single-replica, where a PDB is a no-op. Prod
 # populates this list in values-prod.yaml.
 podDisruptionBudgets: []
+
+# Liveness/readiness probes for inferno-app and inferno-worker.
+#
+# These depend on code that ships in the application image: the /healthz endpoints mounted
+# in config.ru, and scripts/sidekiq_health.rb. inferno.imageUrl is pinned per environment
+# and promoted independently of this chart, so an environment still running an image from
+# before those files existed must keep this off. Otherwise every new pod fails its startup
+# probe, gets killed, and the rollout wedges behind the last healthy pod.
+#
+# Turn it on for an environment in the same change that promotes an image containing them.
+healthProbes:
+  enabled: true


### PR DESCRIPTION
## What broke

The probes added in #159 reference code that ships in the application image (the
`/healthz` endpoints in `config.ru`, and `scripts/sidekiq_health.rb`). The chart and the
image are not promoted together: `inferno.imageUrl` is pinned per environment, and
`values-prod.yaml` currently pins `213f6c89`, which predates both files.

When the chart reached prod, every new pod failed its startup probe:

```
inferno-app     Get "http://10.0.20.240:4567/healthz/live": dial tcp ... connection refused
inferno-worker  /usr/local/bin/ruby: No such file or directory -- scripts/sidekiq_health.rb (LoadError)
```

Kubernetes killed and recreated them in a loop and the rollout wedged. Prod continued
serving only because a Deployment will not retire a working pod for a replacement that
never becomes ready, so the 11-day-old pod held the line. A single eviction would have
taken prod down with no pod able to replace it.

Confirmed directly: the pinned prod image contains neither file.

## The fix

Gate both probe blocks on `healthProbes.enabled`, default `true`, set `false` in
`values-prod.yaml` until prod's pinned image contains the endpoints. Flip it to `true` in
the same change that promotes prod to an image that has them.

This is the right shape rather than a workaround: because images are promoted per
environment, whether a given environment's image supports these endpoints is genuinely
per-environment state, and the chart should express it.

## Verification

Rendered all three value sets:

| environment | probes emitted |
|---|---|
| dev | `/healthz/live`, `/healthz/ready`, `sidekiq_health.rb` |
| preview | same |
| prod | none (zero `healthz` / `sidekiq_health` references) |

Only `validator-api`'s pre-existing probes remain in the prod render.