### PR TITLE
Promote prod -> v1.1.0

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:f7331ce1fec6bbe92ebe1ccbdb6d81b3d80c3a95
   usesWrapper: true
   # HELD AT 1.0.78. Prod stays pinned (never :latest) so promotions are explicit, but
   # this pin is now a deliberate hold rather than a lag: do not advance it without
@@ -39,7 +39,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:213f6c898b0b059a86a477f68f2248b926bea4d0-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:f7331ce1fec6bbe92ebe1ccbdb6d81b3d80c3a95-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `213f6c8` → `f7331ce` — staging already runs this exact artifact.

## Release version
Proposed: **v1.1.0** (minor bump of `v1.0.2`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`213f6c8`)
- Fix 504s on concurrent test-session creation (#159)
- fix(helm): gate health probes on the environment's image supporting them (#161)
- chore: update AU Core test kit to provide an ability to use Endpoint IDs (#155)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/213f6c898b0b059a86a477f68f2248b926bea4d0...f7331ce1fec6bbe92ebe1ccbdb6d81b3d80c3a95

- app:   `ghcr.io/hl7au/au-fhir-inferno:f7331ce1fec6bbe92ebe1ccbdb6d81b3d80c3a95`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:f7331ce1fec6bbe92ebe1ccbdb6d81b3d80c3a95-nginx`
