### PR TITLE
feat(helm): tolerations for the capacity-type-pinned workloads, and a values schema that rejects unknown keys

### DIFF
--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -57,14 +57,33 @@ jobs:
           helm template inferno . -n inferno -f values-prod.yaml > /dev/null
           echo "::endgroup::"
           echo "::group::preview"
+          # Mirrors the inline values block of the inferno-previews ApplicationSet in
+          # aehrc/sparked-argo (apps/inferno-previews.yaml). Keep the KEY SET in step
+          # with it, not just the values: values.schema.json rejects unknown keys, so a
+          # key the ApplicationSet passes but this render omits would break every
+          # preview environment while CI still reported green.
           helm template inferno-pr-0 . -n inferno-pr-0 \
             --set createNamespace=true \
+            --set capacityType=spot \
             --set postgresql.enabled=true \
             --set externalSecrets.enabled=false \
             --set 'postgresql.externaldbhost=' \
+            --set warmer.enabled=false \
             --set autoscaling.enabled=false \
+            --set validatorAutoscaling.enabled=false \
             --set inferno.imageUrl=ghcr.io/hl7au/au-fhir-inferno:ci-pr \
+            --set inferno.usesWrapper=true \
+            --set inferno.replicas=1 \
+            --set inferno.workerReplicas=1 \
             --set nginx.platformImageUri=ghcr.io/hl7au/au-fhir-inferno:ci-nginx-pr \
+            --set validator.replicas=1 \
+            --set validator.storageClassName=gp3-encrypted \
+            --set validator.sessionCacheSize=1 \
+            --set validator.javaOpts=-Xmx2g \
+            --set validator.resources.requests.memory=3Gi \
+            --set validator.resources.requests.cpu=250m \
+            --set validator.resources.limits.memory=4Gi \
+            --set validator.resources.limits.cpu=2000m \
             --set 'ingress.hostnames[0]=pr-0.preview.inferno.sparked-fhir.com' > /dev/null
           echo "::endgroup::"
 

--- a/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno-worker.deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{- with .Values.capacityType }}
         karpenter.sh/capacity-type: {{ . }}
         {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: inferno-worker
         image: {{ .Values.inferno.imageUrl }}

--- a/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/inferno.deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{- with .Values.capacityType }}
         karpenter.sh/capacity-type: {{ . }}
         {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: examplenginx-config
           configMap:

--- a/infra/helm/inferno/templates/deployments/redis.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/redis.deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- with .Values.capacityType }}
         karpenter.sh/capacity-type: {{ . }}
         {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: redis
         image: redis:8.2-alpine

--- a/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
+++ b/infra/helm/inferno/templates/deployments/validator-api.deployment.yaml
@@ -38,6 +38,10 @@ spec:
         {{- with .Values.capacityType }}
         karpenter.sh/capacity-type: {{ . }}
         {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         # The validator is the heaviest pod we run (multi-GB JVM heap, ~9.5Gi resident).
         # Never put two validators on the same node: when two warm up together their real

--- a/infra/helm/inferno/values.schema.json
+++ b/infra/helm/inferno/values.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "inferno-helmd values",
+  "description": "Values contract for the Inferno chart. additionalProperties is false at the top level and on every block this chart owns, so a misspelled or obsolete key fails the render instead of being silently ignored. That silence has already cost real money: preview environments set capacityType before the chart supported it, Helm dropped the unknown key without a word, and every preview kept running on on-demand nodes at roughly twice the price per vCPU with nothing to indicate the setting was inert. Adding a value here is part of adding it to a template.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "inferno",
+    "nginx",
+    "validator",
+    "warmer",
+    "ingress",
+    "redirectIngress",
+    "autoscaling",
+    "externalSecrets",
+    "healthProbes",
+    "postgresql"
+  ],
+  "properties": {
+    "createNamespace": {
+      "type": "boolean",
+      "description": "Render the destination Namespace as a managed resource (preview environments only)."
+    },
+    "capacityType": {
+      "type": ["string", "null"],
+      "description": "Karpenter capacity type pinned via nodeSelector on validator-api, redis, inferno-app and inferno-worker. Null or empty drops the constraint.",
+      "enum": ["on-demand", "spot", "", null]
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Pod tolerations for the same four workloads capacityType pins. Pairs with capacityType: the nodeSelector demands a capacity type, the toleration is what gets the pod onto a pool that taints itself.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "key": { "type": "string" },
+          "operator": { "type": "string", "enum": ["Exists", "Equal"] },
+          "value": { "type": "string" },
+          "effect": { "type": "string", "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute", ""] },
+          "tolerationSeconds": { "type": "integer" }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostnames"],
+      "properties": {
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+    "redirectIngress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "targetUrl": { "type": "string" }
+      }
+    },
+    "inferno": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["imageUrl", "validatorImageUri"],
+      "properties": {
+        "imageUrl": { "type": "string" },
+        "validatorImageUri": { "type": "string" },
+        "terminologyServer": { "type": "string" },
+        "externalValidatorUrl": { "type": ["string", "null"] },
+        "redisUrl": { "type": ["string", "null"] },
+        "railsEnv": { "type": ["string", "null"] },
+        "initializeValidatorSessions": { "type": ["boolean", "null"] },
+        "performanceMonitoring": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "workerReplicas": { "type": "integer", "minimum": 0 },
+        "usesWrapper": {
+          "type": "boolean",
+          "description": "No longer read by any template. Accepted so existing environments that still pass it keep rendering; drop it from the consumer and then from this schema."
+        }
+      }
+    },
+    "nginx": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platformImageUri"],
+      "properties": {
+        "platformImageUri": { "type": "string" }
+      }
+    },
+    "validator": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Singleton by design: the session cache is per-pod and in-memory, so a second replica only thrashes it. See docs/VALIDATOR_OPTIMIZATION.md."
+        },
+        "storageClassName": { "type": "string" },
+        "javaOpts": { "type": "string" },
+        "sessionCacheDuration": { "type": "integer" },
+        "sessionCacheSize": { "type": "integer", "minimum": 1 },
+        "engineReloadThreshold": {
+          "type": ["string", "integer"],
+          "description": "Bytes. Quote it: unquoted, YAML coerces large values to a float and renders 1e+07, which the wrapper's config parser does not read as a byte count."
+        },
+        "terminologyClientUseCacheId": {
+          "type": "string",
+          "description": "Deliberately absent by default so the wrapper default applies; the template only emits the env var when the key is present."
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": { "type": "object" },
+            "limits": { "type": "object" }
+          }
+        }
+      }
+    },
+    "warmer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "string" },
+        "infernoUrl": { "type": "string" },
+        "aucoreServerUrl": { "type": "string" },
+        "auCoreSuites": { "type": "string" },
+        "auPsSuiteId": { "type": "string" },
+        "auPsProfile": { "type": "string" },
+        "pollTimeout": { "type": "integer", "minimum": 1 },
+        "recheckInterval": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 }
+      }
+    },
+    "validatorAutoscaling": {
+      "type": "object",
+      "description": "No longer read by any template: the validator HPA was removed because each session is per-pod in-memory state, so scaling out thrashes the cache. Accepted so existing environments that still pass it keep rendering; drop it from the consumer and then from this schema.",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "roleArn": { "type": "string" },
+        "secretArn": { "type": "string" },
+        "username": { "type": "string" },
+        "region": { "type": "string" }
+      }
+    },
+    "podDisruptionBudgets": {
+      "type": "array",
+      "description": "One entry per workload to protect from voluntary disruption. maxUnavailable defaults to 1.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["app"],
+        "properties": {
+          "app": { "type": "string" },
+          "maxUnavailable": { "type": ["integer", "string"] }
+        }
+      }
+    },
+    "healthProbes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "description": "Values for the bundled bitnami postgresql subchart. Intentionally not constrained here: the subchart's own value tree is coalesced into this key, and it carries its own schema."
+    },
+    "global": {
+      "type": "object",
+      "description": "Helm global values, shared with subcharts. Not constrained here."
+    }
+  }
+}

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -97,6 +97,34 @@ inferno:
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false
 
+nginx:
+  # Reverse proxy in front of inferno-app (templates/deployments/nginx.deployment.yaml,
+  # the backend the HTTPRoute sends "/" to). Same placeholder treatment as
+  # inferno.imageUrl above: always overridden per environment, so this default only
+  # exists to keep the chart renderable on its own.
+  platformImageUri: "ghcr.io/hl7au/au-fhir-inferno:overridden-per-environment-nginx"
+
+# HPA for inferno-app (templates/deployments/inferno.hpa.yaml). OFF by default: only
+# prod autoscales, dev and previews run fixed single replicas. The min/max/target values
+# are carried here so an environment that flips enabled: true without restating them
+# still renders a valid HPA.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+
+# AWS Secrets Manager -> Kubernetes Secret sync for the RDS credential
+# (templates/configs/external-secrets.yaml). OFF by default: dev and prod each enable it
+# with their own IAM role and secret ARN, and previews run an in-namespace Postgres with
+# no external secret at all.
+externalSecrets:
+  enabled: false
+  roleArn: ""
+  secretArn: ""
+  username: "postgres"
+  region: "ap-southeast-2"
+
 validator:
   storageClassName: "gp3-encrypted"  # Use default EBS storage class for validator caches
   # Validator session cache (env: SESSION_CACHE_DURATION / SESSION_CACHE_SIZE on the

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -18,6 +18,37 @@ createNamespace: false
 # Set to null/empty to drop the constraint entirely and let Karpenter's weighting decide.
 capacityType: "on-demand"
 
+# Pod tolerations for the SAME four workloads capacityType pins (validator-api, redis,
+# inferno-app, inferno-worker). Empty by default, so this is a no-op unless an
+# environment opts in.
+#
+# capacityType and this are two halves of one mechanism and only work together. The
+# nodeSelector says "only a node of this capacity type will do"; it does not grant
+# permission to land there. A taint on the NodePool is what withholds that permission,
+# and a matching toleration is what grants it. Pin without tolerate and the pod stays
+# Pending on a tainted pool; tolerate without pin and the pod is merely eligible for
+# that pool rather than held to it.
+#
+# Concretely, the sparkey cluster taints its on-demand NodePool
+# `dedicated=on-demand:NoSchedule` so that only workloads which explicitly opt in can
+# consume on-demand capacity. Karpenter consolidation never relocates a running pod to a
+# cheaper NodePool, so anything that drifts onto on-demand stays there for the life of
+# the pod; the taint is what stops that drift. Any environment left on the on-demand
+# default above must therefore also set:
+#
+#   tolerations:
+#     - key: dedicated
+#       operator: Equal
+#       value: on-demand
+#       effect: NoSchedule
+#
+# Deliberately NOT applied to nginx-app or redirect-nginx. Neither pins a capacity type,
+# so neither needs to tolerate one, and handing them the toleration would make them
+# eligible for on-demand nodes without holding them there, which is the exact drift the
+# taint exists to prevent. If either ever needs on-demand, give it capacityType pinning
+# in the same change, so the pin and the toleration stay paired.
+tolerations: []
+
 ingress:
   hostnames:
     - example.inferno.sparked-fhir.com


### PR DESCRIPTION
## Why

Two problems, one chart.

**1. The chart can pin a pod to a NodePool but cannot get it admitted to one.**

`capacityType` renders a hard `nodeSelector: karpenter.sh/capacity-type: <value>` on validator-api, redis, inferno-app and inferno-worker. There is no `tolerations` block anywhere in the chart. A nodeSelector expresses which nodes will do; it does not grant permission to land on them. A taint withholds that permission and a matching toleration grants it, so pin-without-tolerate means Pending.

The sparkey cluster is about to taint its on-demand Karpenter NodePool `dedicated=on-demand:NoSchedule`, so that only workloads which explicitly opt in can consume on-demand capacity. The reason: Karpenter consolidation never relocates a running pod to a cheaper NodePool, so any pod that drifts onto on-demand is stranded there for its whole life. prod-inferno leaves `capacityType` at the default `on-demand`, so the moment that taint lands, its five pods go Pending. This PR is the prerequisite for applying it.

**2. Helm silently ignores values a chart does not know about.**

This already cost money. Preview environments set `capacityType: spot` to move off on-demand. The chart did not support the key yet, Helm discarded it without a word, and every preview kept running on-demand at roughly twice the price per vCPU. There was no error, so nothing surfaced it until someone read a rendered pod spec.

## What changed

**Tolerations.** A single top-level `tolerations` list, following the `capacityType` precedent of one release-wide knob rather than a per-workload block, rendered on exactly the four workloads `capacityType` pins. Defaults to `[]`.

nginx-app and redirect-nginx deliberately do not get it. Neither pins a capacity type, so neither needs to tolerate one, and giving them the toleration would make them *eligible* for on-demand without *holding* them there, which is precisely the drift the taint exists to prevent. If either ever needs on-demand it should get `capacityType` pinning in the same change, so the pin and the toleration stay paired. That reasoning is written into values.yaml next to the key.

**values.schema.json.** `additionalProperties: false` at the top level and on every block this chart owns, so a misspelled or obsolete key is a hard render failure rather than silence.

Scoped deliberately, after checking what sparked-argo actually passes:

- `postgresql` is left unconstrained: the bitnami subchart's entire value tree coalesces into that key and it carries its own schema. `global` is left open for the same reason.
- `inferno.usesWrapper` and `validatorAutoscaling` are **declared and documented as no longer read by any template**, not rejected. Both are still passed by live environments (`validatorAutoscaling` by the inferno-previews ApplicationSet, `usesWrapper` by dev, prod and previews), so rejecting them today would break every preview the moment this merges. The schema says to drop them from the consumer first, then from the schema.
- Types, enums and bounds on the rest, so `capacityType: sopt` or `healthProbes.enabled: "yes"` fail loudly.

**values.yaml now declares its own defaults.** `nginx`, `autoscaling` and `externalSecrets` were referenced by templates but absent from values.yaml, so `helm lint .` and `helm template .` both failed on a nil pointer and the chart could only render against values an external consumer supplied. A schema whose `required` keys have no defaults would have been a lie. All three are now declared: the nginx image gets the same `overridden-per-environment` placeholder `inferno.imageUrl` already uses, and autoscaling and externalSecrets default off, which is what dev and previews pass anyway. Every real environment overrides all three, so no render moves.

**CI preview render widened** to the full key set the inferno-previews ApplicationSet passes. With unknown keys now fatal, a key the ApplicationSet sends but CI omits would break every preview while CI reported green.

## Verification

`helm template` run before and after against every real consumer configuration. All four are byte identical:

| render | command | result |
| --- | --- | --- |
| dev | `-n dev-inferno -f values.yaml -f values-dev.yaml` | identical |
| prod | `-n prod-inferno -f values.yaml -f values-prod.yaml` | identical |
| preview | `-f values.yaml -f <inline block from apps/inferno-previews.yaml>` | identical |
| chart defaults | before: `-f <the three previously-missing keys>`; after: bare `helm template .` | identical |

`helm lint .` went from failing (`nil pointer evaluating interface {}.platformImageUri`) to clean. The CI preview `--set` invocation renders.

With `tolerations` set, the render adds exactly four hunks, one per capacity-type-pinned workload, and nothing else moves:

```
@@ inferno-worker @@   @@ inferno-app @@   @@ inferno-redis @@   @@ validator-api @@
       nodeSelector:
         kubernetes.io/arch: amd64
         karpenter.sh/capacity-type: on-demand
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: on-demand
```

Schema rejections confirmed:

```
--set capacityTpe=spot            -> at '': additional properties 'capacityTpe' not allowed
--set validator.sessionCashSize=2 -> at '/validator': additional properties 'sessionCashSize' not allowed
--set capacityType=spto           -> at '/capacityType': value must be one of 'on-demand', 'spot', '', <nil>
--set healthProbes.enabled=yes    -> at '/healthProbes/enabled': got string, want boolean
--set 'tolerations[0].keyy=x'     -> at '/tolerations/0': additional properties 'keyy' not allowed
```

## Consumer follow-up

Once this merges, sparked-argo adds to prod-inferno (and any other environment staying on the on-demand default):

```yaml
tolerations:
  - key: dedicated
    operator: Equal
    value: on-demand
    effect: NoSchedule
```

That must land before the NodePool taint, not after. Previews are unaffected: they run `capacityType: spot` on an untainted pool.

## Not done, on purpose

- **nginx-app and inferno-redis declare no resource requests or limits.** nginx-app carries all user traffic (the HTTPRoute sends `/` to it) and runs BestEffort in dev and prod, which makes it first out under node pressure. It is only masked in previews because the guardrail LimitRange injects defaults. Copying the inferno-app nginx sidecar's numbers looked tempting, but that sidecar is not on the traffic path and its 50m CPU limit could throttle ingress under load. Sizing these needs load data, not a guess, so it belongs in its own change.
- **nginx-app has no `capacityType` nodeSelector** while everything around it does, so in prod the user-facing proxy is free to sit on spot while the app it fronts is pinned to on-demand. Possibly intended, possibly an oversight, but changing it moves prod pods and is not this PR's job.
- **No securityContext hardening.** The namespaces carry `pod-security.kubernetes.io/warn|audit: restricted` in non-enforcing mode, so the gap is real, but closing it is a multi-workload change with its own rollout.
