### PR TITLE
feat: record per-runnable execution time on results.duration_ms

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,17 @@ namespace :db do
     require 'inferno/utils/migration'
     Inferno::Utils::Migration.new.run
 
-    # Local migrations are dev-only (performance monitoring schema); gated by
-    # PERFORMANCE_MONITORING_ENABLED so prod's database schema is left untouched.
-    if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
+    # Local migrations are dev-only, so prod's database schema is left untouched. Two
+    # independent features live here and each has its own flag, because they have
+    # different lifespans: the performance monitoring schema is scheduled for removal in
+    # favour of the OpenTelemetry pipeline, while results.duration_ms is a prototype of an
+    # inferno-core change that outlives it.
+    #
+    # Sequel::Migrator applies a directory as a whole, so either flag runs every local
+    # migration present. That is fine while both are dev-only and dev enables both; if
+    # duration tracking is ever wanted somewhere the performance schema is not, delete the
+    # performance migrations at the same time as their flag.
+    if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true' || ENV['RESULT_DURATION_ENABLED'] == 'true'
       require 'sequel'
       local_dir = File.join(__dir__, 'db', 'migrate')
       if File.directory?(local_dir) && !Dir.glob("#{local_dir}/*.rb").empty?

--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,12 @@ require_relative 'lib/inferno_platform_template/patches'
 require_relative 'lib/inferno_platform_template/health_check'
 require_relative 'lib/inferno_platform_template/database_pool'
 
+# Per-runnable duration tracking (results.duration_ms) is dev-only while it is a
+# prototype of an inferno-core change, gated by RESULT_DURATION_ENABLED. The web process
+# needs it for the entity and serializer patches that expose duration_ms on
+# /api/test_sessions/:id/results; the worker needs it to do the measuring (worker.rb).
+require_relative 'lib/inferno_platform_template/result_duration' if ENV['RESULT_DURATION_ENABLED'] == 'true'
+
 # Outermost middleware: /healthz answers before static assets, the request logger and
 # routing, so probes stay cheap and out of the access log.
 use InfernoPlatformTemplate::HealthCheck

--- a/db/migrate/003_add_duration_ms_to_results.rb
+++ b/db/migrate/003_add_duration_ms_to_results.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:results) do
+      add_column :duration_ms, Integer
+    end
+  end
+end

--- a/docs/result-duration.md
+++ b/docs/result-duration.md
@@ -1,0 +1,93 @@
+# Per-runnable duration (`results.duration_ms`)
+
+Records how long each test and group took to execute. Dev-only, gated by
+`RESULT_DURATION_ENABLED` / `inferno.resultDuration`.
+
+This is a **prototype of an inferno-core change**, staged here so it can be validated
+against real AU Core runs before being raised upstream. It is not intended to live in this
+repository long-term.
+
+## Why
+
+inferno-core stores `created_at` / `updated_at` on a result but never how long the runnable
+took. Nothing in the stack can therefore answer the question users actually ask about a slow
+run: *which test ate the time?*
+
+The nearest approximation available today is differencing consecutive results'
+`created_at` within a test run. That breaks down for waiting tests and for any result
+written out of execution order, which parent roll-ups are.
+
+Note this is a different question from the one the `/performance` page answers. That page
+sums outbound FHIR wait and validator wait per session; neither is per-test wall time, and
+neither accounts for Inferno's own CPU. See
+[performance-feature.md](./performance-feature.md).
+
+## How it works
+
+`lib/inferno_platform_template/result_duration.rb` prepends `Inferno::TestRunner`, which is
+the only place that can measure this correctly: it brackets each runnable's execution and
+funnels every write through `#persist_result`.
+
+The patch keeps a stack of monotonic start times, one frame per runnable currently
+executing. `TestRunner` is instantiated per test run and executes it on one thread, so a
+plain instance variable suffices.
+
+| Call | Frame pushed | Effect |
+|---|---|---|
+| `run_test` | start time | the test's own row gets its elapsed time |
+| `run_group` | start time | the group's row spans all of its children |
+| `update_parent_result` | `nil` | suppresses attribution for the recursive roll-up |
+
+The `nil` frame matters. Roll-ups recompute an ancestor's result after its children
+finish, long after the ancestor ran, and they happen while the enclosing test's frame is
+still on the stack. Without suppression a parent would inherit its child's elapsed time.
+
+The duration measures the whole of `run_test` / `run_group`, including input loading,
+instance construction and output persistence, not just the test block. That total is the
+wall time the user experienced, and the difference is where Inferno's own overhead shows up.
+
+Three further patches are needed because inferno-core whitelists at every layer:
+
+| Layer | Why |
+|---|---|
+| `db/migrate/003_add_duration_ms_to_results.rb` | the column itself. `Repository#create` slices params to `Model.columns`, so no repository change is needed once it exists |
+| `Inferno::Entities::Result` | `Entity#initialize` assigns only attributes named in the class's `ATTRIBUTES`, so a `duration_ms` from the database is otherwise dropped |
+| `Inferno::Web::Serializers::Result` | an explicit Blueprinter whitelist; unlisted fields never reach the API |
+
+Both processes load the file: the worker does the measuring (test runs execute there), the
+web process needs the entity and serializer patches to expose the value.
+
+## Validating on dev
+
+```
+GET /api/test_sessions/:id/results
+```
+
+Each result carries `duration_ms`. Worth checking on a full AU Core run:
+
+- tests have plausible durations, groups are >= the sum of their children
+- suite and group roll-up rows are not carrying a child's duration
+- summed test durations versus the session's wall time: the gap is Inferno overhead plus
+  time outside test execution, and quantifying it is the point of the exercise
+- waiting tests, which record time up to the wait; on resume `TestRunner` returns the
+  existing result without persisting again, so the post-resume portion is not counted
+
+## Known limits
+
+- **No UI.** inferno-core ships a prebuilt React bundle (`config.ru` serves
+  `Inferno::Utils::StaticAssets`), so durations cannot appear in the results tree without a
+  core fork and a frontend build. Data and API only.
+- `Result#to_hash` is left alone, so `duration_ms` is absent there. Nothing in this
+  repository reads it; the serializer is what feeds the API.
+- `Sequel::Migrator` applies `db/migrate` as a whole, so enabling either local flag runs
+  every local migration present. Fine while both features are dev-only and dev enables
+  both. See the note in the `Rakefile`.
+
+## Upstreaming
+
+Split the change in two. The data and API half is what this prototype validates and is the
+part every test kit benefits from; raise it first. The UI half needs the frontend build and
+can follow.
+
+Once inferno-core records duration itself, delete `result_duration.rb`, migration `003`,
+the `RESULT_DURATION_ENABLED` plumbing and this document.

--- a/infra/helm/inferno/templates/configs/inferno-configmap.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-configmap.yaml
@@ -10,6 +10,7 @@ data:
   REDIS_URL: {{ default "redis://inferno-redis:6379" .Values.inferno.redisUrl | quote }}
   RAILS_ENV: {{ default "production" .Values.inferno.railsEnv | quote }}
   PERFORMANCE_MONITORING_ENABLED: {{ .Values.inferno.performanceMonitoring | default false | quote }}
+  RESULT_DURATION_ENABLED: {{ .Values.inferno.resultDuration | default false | quote }}
   # Disable inferno_core's boot-time per-suite validator-session warming
   # (config/boot/validator.rb). It validates a throwaway Patient for every suite; au_core_v100
   # and au_core_v200 get handed the same validator sessionId, which collides on the

--- a/infra/helm/inferno/values-dev.yaml
+++ b/infra/helm/inferno/values-dev.yaml
@@ -14,6 +14,7 @@ inferno:
   replicas: 1
   workerReplicas: 1
   performanceMonitoring: true
+  resultDuration: true
 
 validator:
   replicas: 1

--- a/infra/helm/inferno/values.schema.json
+++ b/infra/helm/inferno/values.schema.json
@@ -79,6 +79,7 @@
         "railsEnv": { "type": ["string", "null"] },
         "initializeValidatorSessions": { "type": ["boolean", "null"] },
         "performanceMonitoring": { "type": "boolean" },
+        "resultDuration": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
         "workerReplicas": { "type": "integer", "minimum": 0 },
         "usesWrapper": {

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -96,6 +96,12 @@ inferno:
   # Performance monitoring (request/validator timing + /performance page + its DB
   # migration). Dev-only feature; OFF by default, enabled per-env in values-dev.yaml.
   performanceMonitoring: false
+  # Per-runnable execution time on results.duration_ms, plus its DB migration. Prototype
+  # of an inferno-core change, kept dev-only until it lands upstream; OFF by default,
+  # enabled per-env in values-dev.yaml. Flagged separately from performanceMonitoring
+  # because that feature is being retired in favour of the OpenTelemetry pipeline and this
+  # one is not.
+  resultDuration: false
 
 nginx:
   # Reverse proxy in front of inferno-app (templates/deployments/nginx.deployment.yaml,

--- a/lib/inferno_platform_template/result_duration.rb
+++ b/lib/inferno_platform_template/result_duration.rb
@@ -1,0 +1,101 @@
+# Record how long each test and group took to execute, on `results.duration_ms`.
+#
+# inferno-core stores `created_at` / `updated_at` on a result but never how long the
+# runnable took, so nothing in the stack can answer the question a user actually asks
+# about a slow run: "which test ate the time?". Per-test wall time can only be
+# approximated today, by differencing consecutive results' `created_at` within a test
+# run, which breaks down for waiting tests and for any result written out of execution
+# order (parent roll-ups).
+#
+# This is a prototype of a change that belongs in inferno-core: `TestRunner` already
+# brackets each runnable's execution and funnels every write through `#persist_result`,
+# so core is the only place that can measure this correctly and the only place whose
+# results UI can display it. Implemented here as a prepend so it can be validated
+# against real AU Core runs on dev before being raised upstream. Remove this file, its
+# migration and its env flag once inferno-core records duration itself.
+# See https://github.com/inferno-framework/inferno-core
+#
+# Note this deliberately measures the whole of `run_test` / `run_group` (input loading,
+# instance construction, the test block, output persistence), not just the test block:
+# that total is the wall time the user experienced, and the difference is where
+# inferno's own overhead would show up.
+
+require 'inferno'
+require 'inferno/test_runner'
+require 'inferno/apps/web/serializers/result'
+
+module InfernoPlatformTemplate
+  # Times each runnable and attaches the result to the row `TestRunner` persists for it.
+  #
+  # `TestRunner` is instantiated once per test run and executes it on a single thread,
+  # so a plain instance variable is sufficient state; no thread-locals needed.
+  module ResultDurationPatch
+    # One frame per runnable currently executing, innermost last. A `nil` frame marks a
+    # region whose writes must NOT be attributed a duration.
+    def duration_frames
+      @duration_frames ||= []
+    end
+
+    # `...` forwarding throughout so the patch does not restate, and cannot drift from,
+    # inferno-core's signatures.
+    def run_test(...)
+      duration_frames.push(monotonic_ms)
+      super
+    ensure
+      duration_frames.pop
+    end
+
+    def run_group(...)
+      duration_frames.push(monotonic_ms)
+      super
+    ensure
+      duration_frames.pop
+    end
+
+    # Parent roll-ups recompute an ancestor's result after its children finish, long
+    # after the ancestor itself ran. Elapsed time is meaningless for those writes, and
+    # the enclosing test's frame is still on the stack when they happen, so push a nil
+    # frame to suppress attribution for the whole recursive roll-up.
+    def update_parent_result(...)
+      duration_frames.push(nil)
+      super
+    ensure
+      duration_frames.pop
+    end
+
+    def persist_result(params)
+      started_at_ms = duration_frames.last
+      return super if started_at_ms.nil?
+
+      super(params.merge(duration_ms: monotonic_ms - started_at_ms))
+    end
+
+    private
+
+    def monotonic_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+    end
+  end
+
+  # `Inferno::Entities::Entity#initialize` assigns only the attributes named in the
+  # class's ATTRIBUTES list, so a `duration_ms` coming back from the database is
+  # otherwise dropped on the way from the repository to the entity.
+  module ResultDurationAttribute
+    attr_accessor :duration_ms
+
+    def initialize(params)
+      super
+      @duration_ms = params[:duration_ms]
+    end
+  end
+end
+
+Inferno::TestRunner.prepend(InfernoPlatformTemplate::ResultDurationPatch)
+Inferno::Entities::Result.prepend(InfernoPlatformTemplate::ResultDurationAttribute)
+
+# The result serializer is an explicit Blueprinter whitelist, so the field has to be
+# declared for it to reach /api/test_sessions/:id/results. `field_present?` treats 0 as
+# present (only nil/false/empty are blank), so sub-millisecond runnables still report.
+Inferno::Web::Serializers::Result.class_eval do
+  field :duration_ms, if: :field_present?
+end

--- a/spec/inferno_deployment/result_duration_spec.rb
+++ b/spec/inferno_deployment/result_duration_spec.rb
@@ -1,0 +1,178 @@
+require_relative '../../lib/inferno_platform_template/result_duration'
+
+# Exercises the frame-stack attribution logic against a stand-in that reproduces the call
+# structure ResultDurationPatch is prepended onto in Inferno::TestRunner: run_test and
+# run_group both persist a result and then trigger a recursive parent roll-up, and
+# run_group calls run_test for its children. The interesting behaviour is which of those
+# writes gets a duration, which is independent of anything Inferno or the database do.
+#
+# Durations are compared loosely. Process::CLOCK_MONOTONIC in :millisecond truncates both
+# endpoints, so a measured elapsed time is within a millisecond either side of the real
+# one, and exact arithmetic on the values would be flaky.
+# Defined outside the example group: constants assigned inside an RSpec block land on the
+# example group class, which the anonymous Class.new bodies below cannot resolve.
+SLEEP_SECONDS = 0.01
+SLEEP_MS = 10
+
+RSpec.describe InfernoPlatformTemplate::ResultDurationPatch do
+  let(:runner_class) do
+    Class.new do
+      attr_reader :persisted
+
+      def initialize
+        @persisted = []
+      end
+
+      def run_test(test, _scratch = {})
+        sleep SLEEP_SECONDS
+        persist_result(name: test)
+        update_parent_result("#{test}-parent")
+      end
+
+      def run_group(group, scratch = {})
+        %w[child-a child-b].each { |child| run_test(child, scratch) }
+        persist_result(name: group)
+        update_parent_result("#{group}-parent")
+      end
+
+      # Mirrors TestRunner#update_parent_result recursing up the tree, persisting an
+      # ancestor's recomputed result at each level.
+      def update_parent_result(parent, depth = 2)
+        return if depth.zero?
+
+        persist_result(name: parent)
+        update_parent_result("#{parent}-up", depth - 1)
+      end
+
+      def persist_result(params)
+        @persisted << params
+        params
+      end
+    end.tap { |klass| klass.prepend(described_class) }
+  end
+
+  let(:runner) { runner_class.new }
+
+  def durations_by_name
+    runner.persisted.to_h { |params| [params[:name], params[:duration_ms]] }
+  end
+
+  describe 'a single test' do
+    before { runner.run_test('test-1') }
+
+    it 'attributes a measured duration to the test' do
+      expect(durations_by_name['test-1']).to be_a(Integer)
+      expect(durations_by_name['test-1']).to be >= SLEEP_MS - 1
+    end
+
+    it 'leaves parent roll-ups without a duration' do
+      roll_ups = runner.persisted.reject { |params| params[:name] == 'test-1' }
+
+      expect(roll_ups).to_not be_empty
+      expect(roll_ups.map { |params| params[:duration_ms] }).to all(be_nil)
+    end
+  end
+
+  describe 'a group' do
+    before { runner.run_group('group-1') }
+
+    it 'times each child independently of the group' do
+      expect(durations_by_name['child-a']).to be >= SLEEP_MS - 1
+      expect(durations_by_name['child-b']).to be >= SLEEP_MS - 1
+    end
+
+    it "times the group across the whole of its children's execution" do
+      # The bug this guards against is the group inheriting a child's frame, which would
+      # report roughly one child's time rather than both.
+      expect(durations_by_name['group-1']).to be >= (2 * SLEEP_MS) - 1
+      expect(durations_by_name['group-1']).to be >= durations_by_name['child-a']
+    end
+
+    it 'does not let a child frame leak into the group roll-up' do
+      expect(durations_by_name['group-1-parent']).to be_nil
+    end
+  end
+
+  describe 'frame bookkeeping' do
+    it 'unwinds every frame once a run completes' do
+      runner.run_group('group-1')
+
+      expect(runner.duration_frames).to be_empty
+    end
+
+    it 'unwinds the frame when the runnable raises' do
+      # The raise has to come from the method the patch wraps, so it is defined on the
+      # class the module is prepended onto. A singleton method would shadow the patch
+      # instead of being called by it, and the test would prove nothing.
+      raising_class = Class.new do
+        def run_test(_test, _scratch = {})
+          raise 'boom'
+        end
+
+        def persist_result(params) = params
+      end
+      raising_class.prepend(described_class)
+      raising_runner = raising_class.new
+
+      expect { raising_runner.run_test('test-1') }.to raise_error('boom')
+      expect(raising_runner.duration_frames).to be_empty
+    end
+
+    it 'records no duration for a write outside any frame' do
+      runner.persist_result(name: 'orphan')
+
+      expect(durations_by_name['orphan']).to be_nil
+    end
+  end
+end
+
+# The unit tests above prove the attribution logic. These prove the patch actually binds to
+# the inferno-core it is prepended onto, which is the part that breaks silently on a gem
+# upgrade: a renamed method or a serializer that stops accepting a reopened field would
+# leave duration_ms quietly absent rather than raising.
+RSpec.describe 'result duration integration with inferno-core' do
+  def result(attributes = {})
+    Inferno::Entities::Result.new(
+      { id: SecureRandom.uuid, result: 'pass', test_session_id: 'session', test_run_id: 'run' }
+        .merge(attributes)
+    )
+  end
+
+  it 'prepends the patch onto TestRunner' do
+    expect(Inferno::TestRunner.ancestors).to include(InfernoPlatformTemplate::ResultDurationPatch)
+  end
+
+  it 'wraps the TestRunner methods it means to wrap' do
+    owners = [:run_test, :run_group, :update_parent_result, :persist_result].to_h do |name|
+      [name, Inferno::TestRunner.instance_method(name).owner]
+    end
+
+    expect(owners.values).to all(eq(InfernoPlatformTemplate::ResultDurationPatch))
+  end
+
+  it 'carries duration_ms through the Result entity' do
+    expect(result(duration_ms: 1234).duration_ms).to eq(1234)
+  end
+
+  it 'leaves duration_ms nil when absent' do
+    expect(result.duration_ms).to be_nil
+  end
+
+  it 'serializes duration_ms for the API' do
+    rendered = Inferno::Web::Serializers::Result.render_as_hash(result(duration_ms: 1234))
+
+    expect(rendered[:duration_ms]).to eq(1234)
+  end
+
+  it 'serializes a 0ms duration rather than dropping it as blank' do
+    rendered = Inferno::Web::Serializers::Result.render_as_hash(result(duration_ms: 0))
+
+    expect(rendered[:duration_ms]).to eq(0)
+  end
+
+  it 'omits duration_ms entirely when it was never recorded' do
+    rendered = Inferno::Web::Serializers::Result.render_as_hash(result)
+
+    expect(rendered).to_not have_key(:duration_ms)
+  end
+end

--- a/worker.rb
+++ b/worker.rb
@@ -11,6 +11,10 @@ if ENV['PERFORMANCE_MONITORING_ENABLED'] == 'true'
   require_relative 'lib/inferno_platform_template/validator_timing'
 end
 
+# Per-runnable duration tracking is dev-only (see config.ru). Test runs execute in this
+# process, so this is where the measuring happens.
+require_relative 'lib/inferno_platform_template/result_duration' if ENV['RESULT_DURATION_ENABLED'] == 'true'
+
 # Configure OpenTelemetry for inferno-worker spans.
 # Env vars set by the Helm chart:
 #   OTEL_SERVICE_NAME              = inferno-worker


### PR DESCRIPTION
Records how long each test and group took to execute. Dev-only, gated by `RESULT_DURATION_ENABLED` / `inferno.resultDuration`.

This is a **prototype of an inferno-core change**, staged here so it can be validated against real AU Core runs before being raised upstream. See `docs/result-duration.md`.

## Why

inferno-core stores `created_at` / `updated_at` on a result but never how long the runnable took, so nothing in the stack can answer the question users ask about a slow run: which test ate the time. The nearest approximation available today is differencing consecutive results' `created_at` within a test run, which breaks down for waiting tests and for any result written out of execution order, as parent roll-ups are.

This is distinct from what the `/performance` page measures. That page sums outbound FHIR wait and validator wait per session; neither is per-test wall time, and neither accounts for Inferno's own CPU.

## Approach

Prepends `Inferno::TestRunner`, which brackets each runnable's execution and funnels every write through `#persist_result`. The patch keeps a stack of monotonic start times, one frame per executing runnable:

| Call | Frame | Effect |
|---|---|---|
| `run_test` | start time | the test's row gets its elapsed time |
| `run_group` | start time | the group's row spans all of its children |
| `update_parent_result` | `nil` | suppresses attribution for the recursive roll-up |

The `nil` frame is the subtle part. Roll-ups recompute an ancestor's result after its children finish, while the enclosing test's frame is still on the stack; without suppression a parent would inherit its child's elapsed time.

Three further patches are needed because core whitelists at every layer: the column itself (`Repository#create` then slices params to `Model.columns`, so no repository change is required), `Entities::Result` (whose `Entity#initialize` assigns only attributes named in `ATTRIBUTES`), and the Blueprinter result serializer (which never emits unlisted fields).

All wrapped methods use `...` forwarding so the patch cannot drift from core's signatures.

## Flag

Gated on a new `RESULT_DURATION_ENABLED` rather than reusing `PERFORMANCE_MONITORING_ENABLED`, because the performance monitoring schema is scheduled for removal in favour of the OpenTelemetry pipeline and this outlives it. `Sequel::Migrator` applies `db/migrate` as a whole, so either flag runs every local migration; noted in the `Rakefile`.

## Verification

- 15 new examples, full suite green (16 examples, 0 failures). Unit tests cover the frame-stack attribution (child/group/roll-up, unwinding on raise, writes outside any frame); integration tests assert the patch actually binds to real inferno-core, that the serializer emits `duration_ms`, keeps `0`, and omits `nil`.
- Migration applied against a scratch SQLite DB: `results` gains `duration_ms`, values round-trip, column is nullable.
- `helm template` renders under the strict values schema: `RESULT_DURATION_ENABLED` is `"true"` with `values-dev.yaml` and `"false"` on chart defaults.

## Known limits

- **No UI.** inferno-core ships a prebuilt React bundle, so durations cannot appear in the results tree without a core fork and a frontend build. Data and API only; read it from `GET /api/test_sessions/:id/results`.
- Waiting tests record time up to the wait. On resume `TestRunner` returns the existing result without persisting again, so the post-resume portion is not counted.
- `Result#to_hash` is left alone; nothing in this repository reads it and the serializer is what feeds the API.

## Next

Validate on dev over a full AU Core run, then split the upstream change: data + API first, UI after.