### PR TITLE
Promote prod -> v1.0.3

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:632158f5f70a2be07a5fe8b12d6e048a6e1d593d
   usesWrapper: true
   # HELD AT 1.0.78. Prod stays pinned (never :latest) so promotions are explicit, but
   # this pin is now a deliberate hold rather than a lag: do not advance it without
@@ -39,7 +39,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:632158f5f70a2be07a5fe8b12d6e048a6e1d593d-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `0d05749` → `632158f` — staging already runs this exact artifact.

## Release version
Proposed: **v1.0.3** (patch bump of `v1.0.2`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`0d05749`)
- perf(validator): right-size JVM heap from live-heap telemetry, pin reload guard (#156)
- Fix 504s on concurrent test-session creation (#159)
- fix(helm): gate health probes on the environment's image supporting them (#161)
- chore: update AU Core test kit to provide an ability to use Endpoint IDs (#155)
- docs: brief the unresolved 10-concurrent 504 at the Inferno app tier (#158)
- feat(helm): tolerations for the capacity-type-pinned workloads, and a values schema that rejects unknown keys (#164)
- feat: record per-runnable execution time on results.duration_ms (#166)
- feat: trace the web process, retire the bespoke performance page (#169)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/0d05749081407f8ac8f9bb730b99e83a40161e49...632158f5f70a2be07a5fe8b12d6e048a6e1d593d

- app:   `ghcr.io/hl7au/au-fhir-inferno:632158f5f70a2be07a5fe8b12d6e048a6e1d593d`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:632158f5f70a2be07a5fe8b12d6e048a6e1d593d-nginx`
