### PR TITLE
fix: count result persistence in duration_ms, and trace it

### DIFF
--- a/docs/result-duration.md
+++ b/docs/result-duration.md
@@ -44,8 +44,37 @@ finish, long after the ancestor ran, and they happen while the enclosing test's 
 still on the stack. Without suppression a parent would inherit its child's elapsed time.
 
 The duration measures the whole of `run_test` / `run_group`, including input loading,
-instance construction and output persistence, not just the test block. That total is the
-wall time the user experienced, and the difference is where Inferno's own overhead shows up.
+instance construction, saving outputs and writing the result, not just the test block. That
+total is the wall time the user experienced, and the difference is where Inferno's own
+overhead shows up.
+
+### Why it takes two writes
+
+A result row cannot carry the cost of writing itself. `#persist_result` therefore inserts
+the time spent executing the runnable, then updates the row with the elapsed time once the
+write has finished. `super` inside `#persist_result` is exactly `Repositories::Results#create`,
+so the second reading covers the whole write and none of the parent roll-up that `run_group`
+performs afterwards.
+
+The extra write earns its place, because on this workload persistence is not a rounding
+error. Measured over a 498-test AU Core run on dev (session `bcT7dNjmwrt`, run duration
+414.8 s), against the OpenTelemetry `inferno.test` spans that bracket the same method:
+
+| | | |
+|---|---|---|
+| Executing tests | 226.0 s | 54% |
+| Writing their results | 186.6 s | 45% |
+| Everything else in the run | 2.2 s | 1% |
+
+`Repositories::Results#create` writes a row per message and per request, and
+`Repositories::Requests#create` a row per HTTP header, all one INSERT at a time: **38,139
+rows** for that run, 29,889 of them headers. The cost tracks request count almost exactly
+(r = 0.906, roughly 100 ms per persisted request), so measuring only up to the start of the
+write would have understated precisely the request-heavy tests a user is hunting for. One
+test recorded 1.07 s against 3.31 s actually elapsed.
+
+The corrective UPDATE is a single row by primary key, one per result: 533 for that run,
+against the 38,139 INSERTs it already performs.
 
 Three further patches are needed because inferno-core whitelists at every layer:
 
@@ -72,6 +101,17 @@ Each result carries `duration_ms`. Worth checking on a full AU Core run:
   time outside test execution, and quantifying it is the point of the exercise
 - waiting tests, which record time up to the wait; on resume `TestRunner` returns the
   existing result without persisting again, so the post-resume portion is not counted
+
+The check worth repeating is against the traces, since they measure the same method from
+outside the process and so cannot share a mistake with the patch:
+
+```
+{ span.inferno.test_session_id = "<session>" && name = "inferno.test" }
+```
+
+Sum those span durations and compare to the summed `duration_ms` for the session's tests.
+They should now agree within the tracing overhead itself (a few ms per test). A large,
+request-correlated shortfall in `duration_ms` means the corrective update is not running.
 
 ## Known limits
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -51,6 +51,37 @@ errors would pollute every error-rate panel and alert.
 The Sidekiq job span carries `inferno.test_run_id`, `inferno.test_session_id` and
 `inferno.suite_id`.
 
+### `inferno.persist_result`
+
+A child of the test span, covering `Repositories::Results#create`: the result row plus a row
+per message, a row per request and a row per HTTP header, one INSERT at a time.
+
+| Attribute | Why |
+|---|---|
+| `inferno.messages_persisted` | rows written for this result's messages |
+| `inferno.requests_persisted` | rows written for this result's requests; the count the cost tracks |
+
+It has a span because nothing else can see it. It is not an HTTP call, so no instrumentation
+covers it, and it sits inside `run_test`, so it is already counted in the test span and in
+`results.duration_ms` without being separable from test execution there.
+
+It is not a minor cost. On a 498-test AU Core run on dev (session `bcT7dNjmwrt`, 414.8 s):
+
+| | | |
+|---|---|---|
+| Executing tests | 226.0 s | 54% |
+| Writing their results | 186.6 s | 45% |
+| Everything else in the run | 2.2 s | 1% |
+
+That run wrote 38,139 rows, 29,889 of them headers. Persistence time correlates with request
+count at r = 0.906, roughly 100 ms per persisted request, and it is not database latency: a
+round trip to Postgres from the worker measures 0.25 ms.
+
+```
+{ span.inferno.test_session_id = "<session>" && name = "inferno.persist_result" }
+  | select(span.inferno.requests_persisted)
+```
+
 ## Why the span name is a constant
 
 Test spans are all named `inferno.test`. The identity lives in attributes, deliberately.

--- a/lib/inferno_platform_template/result_duration.rb
+++ b/lib/inferno_platform_template/result_duration.rb
@@ -16,9 +16,22 @@
 # See https://github.com/inferno-framework/inferno-core
 #
 # Note this deliberately measures the whole of `run_test` / `run_group` (input loading,
-# instance construction, the test block, output persistence), not just the test block:
-# that total is the wall time the user experienced, and the difference is where
-# inferno's own overhead would show up.
+# instance construction, the test block, saving outputs and writing the result), not just
+# the test block: that total is the wall time the user experienced, and the difference is
+# where inferno's own overhead would show up.
+#
+# Writing the result is a large part of that overhead, which is why it takes two writes to
+# record (see `#persist_result`). Measured over a 498-test AU Core run on dev:
+#
+#   executing tests                      226.0 s   54%
+#   writing their results                186.6 s   45%
+#   everything else in the run             2.2 s    1%
+#
+# `Repositories::Results#create` writes a row per message and per request, and
+# `Repositories::Requests#create` a row per HTTP header, all one INSERT at a time: 38,139
+# rows for that run, 29,889 of them headers. Measuring only up to the start of that write
+# would have reported 226.0 s of a 414.8 s run and, worse, would have understated exactly
+# the request-heavy tests a user is looking for (a 3.3 s test reporting 1.1 s).
 
 require 'inferno'
 require 'inferno/test_runner'
@@ -63,14 +76,34 @@ module InfernoPlatformTemplate
       duration_frames.pop
     end
 
+    # A result row cannot carry the cost of writing itself, so this takes two writes: the
+    # INSERT gets the time spent executing the runnable, then an UPDATE corrects it to the
+    # elapsed time including persistence, once persistence has finished.
+    #
+    # `super` here is exactly the whole write (`results_repo.create`, which cascades into
+    # the message, request and header rows), so the second reading covers all of it and
+    # none of the parent roll-up that `run_group` performs afterwards.
+    #
+    # The extra UPDATE is one row against a primary key, per result: 533 of them for the
+    # run above, against the 38,139 INSERTs it already performs.
     def persist_result(params)
       started_at_ms = duration_frames.last
       return super if started_at_ms.nil?
 
-      super(params.merge(duration_ms: monotonic_ms - started_at_ms))
+      result = super(params.merge(duration_ms: monotonic_ms - started_at_ms))
+      record_total_duration(result, monotonic_ms - started_at_ms)
     end
 
     private
+
+    # Keeps the in-memory entity consistent with the row. `TestRunner` hands the entity
+    # back to the caller in `run_results`, so leaving it holding the execution-only value
+    # would make the API and a directly returned result disagree.
+    def record_total_duration(result, duration_ms)
+      results_repo.update(result.id, duration_ms:)
+      result.duration_ms = duration_ms
+      result
+    end
 
     def monotonic_ms
       Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)

--- a/lib/inferno_platform_template/test_tracing.rb
+++ b/lib/inferno_platform_template/test_tracing.rb
@@ -41,15 +41,29 @@ if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
 
   module PerTestTraceRoot
     SPAN_NAME = 'inferno.test'.freeze
+    PERSIST_SPAN_NAME = 'inferno.persist_result'.freeze
 
     def run_test(test, scratch)
-      tracer = OpenTelemetry.tracer_provider.tracer('inferno-worker')
       # Detach from the enclosing Sidekiq job span so the test span starts a new trace.
       OpenTelemetry::Context.with_current(OpenTelemetry::Context.empty) do
         tracer.in_span(SPAN_NAME, attributes: test_span_attributes(test)) do |span|
           super.tap { |result| annotate_test_result(span, result) }
         end
       end
+    end
+
+    # Writing a result is the second largest cost in a run, behind executing the tests
+    # themselves and ahead of everything else: 186.6 s of a 414.8 s AU Core run on dev.
+    # `Repositories::Results#create` writes a row per message and per request, and
+    # `Repositories::Requests#create` a row per HTTP header, one INSERT at a time, which
+    # came to 38,139 rows for that run.
+    #
+    # It is worth its own span because nothing else can see it. It is not an HTTP call, so
+    # no instrumentation covers it, and it is inside `run_test`, so it is already counted
+    # in the test span and in `results.duration_ms` without being distinguishable there.
+    # As a child of the test span it also inherits that test's identity for free.
+    def persist_result(params)
+      tracer.in_span(PERSIST_SPAN_NAME, attributes: persist_span_attributes(params)) { super }
     end
 
     # A whole run executes inside one Sidekiq job, and the Sidekiq instrumentation already
@@ -63,6 +77,19 @@ if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
     end
 
     private
+
+    def tracer
+      OpenTelemetry.tracer_provider.tracer('inferno-worker')
+    end
+
+    # The row counts are what make a slow write explicable rather than merely visible: the
+    # cost tracks the number of requests being written almost exactly.
+    def persist_span_attributes(params)
+      {
+        'inferno.messages_persisted' => (params[:messages] || []).size,
+        'inferno.requests_persisted' => (params[:requests] || []).size
+      }
+    end
 
     def run_span_attributes
       {

--- a/spec/inferno_deployment/per_test_trace_root_spec.rb
+++ b/spec/inferno_deployment/per_test_trace_root_spec.rb
@@ -38,10 +38,15 @@ RSpec.describe PerTestTraceRoot do
   # whose return value is the persisted result, as the real one's is.
   let(:runner_class) do
     Class.new do
-      attr_accessor :test_run, :test_session, :next_result
+      attr_accessor :test_run, :test_session, :next_result, :persist_params
 
       def run_test(_test, _scratch = {})
+        persist_result(@persist_params) if @persist_params
         @next_result
+      end
+
+      def persist_result(_params)
+        :persisted
       end
 
       def start
@@ -145,6 +150,57 @@ RSpec.describe PerTestTraceRoot do
 
     it 'tolerates a nil outcome' do
       expect { run(outcome: nil) }.to_not raise_error
+    end
+  end
+
+  describe 'the result-persistence span' do
+    # Two messages and three requests, which is all the patch reads from the params.
+    let(:params) { { messages: [{}, {}], requests: [{}, {}, {}] } }
+
+    before { runner.persist_params = params }
+
+    def persist_span
+      run.find { |span| span.name == 'inferno.persist_result' }
+    end
+
+    it 'emits a span for the write' do
+      expect(run.map(&:name)).to contain_exactly('inferno.persist_result', 'inferno.test')
+    end
+
+    it 'nests it inside the test span, so it inherits that test identity' do
+      spans = run
+      test_span = spans.find { |span| span.name == 'inferno.test' }
+      persist = spans.find { |span| span.name == 'inferno.persist_result' }
+
+      expect(persist.parent_span_id).to eq(test_span.span_id)
+      expect(persist.trace_id).to eq(test_span.trace_id)
+    end
+
+    it 'records the row counts that explain the cost' do
+      expect(persist_span.attributes['inferno.messages_persisted']).to eq(2)
+      expect(persist_span.attributes['inferno.requests_persisted']).to eq(3)
+    end
+
+    it 'reports zero rather than omitting the counts when there is nothing to write' do
+      runner.persist_params = { result: 'pass' }
+
+      expect(persist_span.attributes['inferno.messages_persisted']).to eq(0)
+      expect(persist_span.attributes['inferno.requests_persisted']).to eq(0)
+    end
+
+    it 'passes the persisted result through unchanged' do
+      expect(runner.persist_result(params)).to eq(:persisted)
+    end
+  end
+
+  # The methods this patch wraps are called from outside the runner: Jobs::ExecuteTestRun
+  # calls #start, and #persist_result is public API on TestRunner. A `private` placed above
+  # a wrapper in the module would make the wrapped method private on TestRunner too, and
+  # the failure would only surface when a real run started.
+  describe 'visibility of the wrapped methods' do
+    it 'leaves them public on TestRunner' do
+      expect(Inferno::TestRunner.public_instance_methods)
+        .to include(:start, :run_test, :persist_result)
     end
   end
 

--- a/spec/inferno_deployment/result_duration_spec.rb
+++ b/spec/inferno_deployment/result_duration_spec.rb
@@ -6,6 +6,11 @@ require_relative '../../lib/inferno_platform_template/result_duration'
 # run_group calls run_test for its children. The interesting behaviour is which of those
 # writes gets a duration, which is independent of anything Inferno or the database do.
 #
+# The stand-in sleeps inside persist_result as well as inside the runnable, because the two
+# are measured differently: a result row cannot carry the cost of writing itself, so the
+# patch inserts the execution time and then updates the row with the total. Separating the
+# sleeps is what makes the difference between the two values observable.
+#
 # Durations are compared loosely. Process::CLOCK_MONOTONIC in :millisecond truncates both
 # endpoints, so a measured elapsed time is within a millisecond either side of the real
 # one, and exact arithmetic on the values would be flaky.
@@ -13,26 +18,54 @@ require_relative '../../lib/inferno_platform_template/result_duration'
 # example group class, which the anonymous Class.new bodies below cannot resolve.
 SLEEP_SECONDS = 0.01
 SLEEP_MS = 10
+PERSIST_SLEEP_SECONDS = 0.02
+PERSIST_SLEEP_MS = 20
+
+# Stands in for Inferno::Repositories::Results and the Result entity it returns. Only the
+# two things the patch touches are modelled: create returns something with an `id` and a
+# writable `duration_ms`, and update writes to the stored row rather than the entity.
+class FakeResultsRepo
+  Result = Struct.new(:id, :duration_ms)
+
+  attr_reader :rows
+
+  def initialize
+    @rows = {}
+  end
+
+  def create(name, duration_ms)
+    id = "result-#{@rows.size}"
+    @rows[id] = { name:, duration_ms: }
+    Result.new(id, duration_ms)
+  end
+
+  def update(entity_id, params = {})
+    @rows.fetch(entity_id).merge!(params)
+  end
+end
 
 RSpec.describe InfernoPlatformTemplate::ResultDurationPatch do
   let(:runner_class) do
     Class.new do
-      attr_reader :persisted
+      attr_reader :results_repo, :inserted
 
       def initialize
-        @persisted = []
+        @results_repo = FakeResultsRepo.new
+        @inserted = []
       end
 
       def run_test(test, _scratch = {})
         sleep SLEEP_SECONDS
-        persist_result(name: test)
+        result = persist_result(name: test)
         update_parent_result("#{test}-parent")
+        result
       end
 
       def run_group(group, scratch = {})
         %w[child-a child-b].each { |child| run_test(child, scratch) }
-        persist_result(name: group)
+        result = persist_result(name: group)
         update_parent_result("#{group}-parent")
+        result
       end
 
       # Mirrors TestRunner#update_parent_result recursing up the tree, persisting an
@@ -44,17 +77,26 @@ RSpec.describe InfernoPlatformTemplate::ResultDurationPatch do
         update_parent_result("#{parent}-up", depth - 1)
       end
 
+      # Mirrors TestRunner#persist_result: the write cascades into the message, request and
+      # header rows, which is the cost the second reading exists to capture.
       def persist_result(params)
-        @persisted << params
-        params
+        @inserted << params
+        sleep PERSIST_SLEEP_SECONDS
+        @results_repo.create(params[:name], params[:duration_ms])
       end
     end.tap { |klass| klass.prepend(described_class) }
   end
 
   let(:runner) { runner_class.new }
 
+  # What ends up on the row, which is what the API serves.
   def durations_by_name
-    runner.persisted.to_h { |params| [params[:name], params[:duration_ms]] }
+    runner.results_repo.rows.values.to_h { |row| [row[:name], row[:duration_ms]] }
+  end
+
+  # What the INSERT carried, before the corrective update.
+  def inserted_durations_by_name
+    runner.inserted.to_h { |params| [params[:name], params[:duration_ms]] }
   end
 
   describe 'a single test' do
@@ -66,10 +108,45 @@ RSpec.describe InfernoPlatformTemplate::ResultDurationPatch do
     end
 
     it 'leaves parent roll-ups without a duration' do
-      roll_ups = runner.persisted.reject { |params| params[:name] == 'test-1' }
+      roll_ups = runner.results_repo.rows.values.reject { |row| row[:name] == 'test-1' }
 
       expect(roll_ups).to_not be_empty
-      expect(roll_ups.map { |params| params[:duration_ms] }).to all(be_nil)
+      expect(roll_ups.map { |row| row[:duration_ms] }).to all(be_nil)
+    end
+
+    it 'issues no corrective update for a roll-up' do
+      # A nil frame must skip the update as well as the insert, or the patch would write a
+      # duration onto rows it deliberately declined to time.
+      expect(runner.results_repo.rows.values.count { |row| row[:duration_ms] }).to eq(1)
+    end
+  end
+
+  describe 'the cost of writing the result' do
+    before { runner.run_test('test-1') }
+
+    it 'counts persistence towards the recorded duration' do
+      # The reason this matters: on a real AU Core run the write is 45% of the elapsed
+      # time, and it scales with how many requests the test made, so omitting it
+      # understates exactly the request-heavy tests a user is hunting for.
+      expect(durations_by_name['test-1']).to be >= (SLEEP_MS + PERSIST_SLEEP_MS) - 1
+    end
+
+    it 'inserts the execution time and corrects it afterwards' do
+      inserted = inserted_durations_by_name['test-1']
+
+      expect(inserted).to be >= SLEEP_MS - 1
+      expect(inserted).to be < SLEEP_MS + PERSIST_SLEEP_MS
+      expect(durations_by_name['test-1']).to be > inserted
+    end
+
+    it 'corrects the row it just inserted rather than creating another' do
+      expect(runner.results_repo.rows.count { |_id, row| row[:name] == 'test-1' }).to eq(1)
+    end
+
+    it 'leaves the returned entity agreeing with the row' do
+      result = runner.run_test('test-2')
+
+      expect(result.duration_ms).to eq(durations_by_name['test-2'])
     end
   end
 


### PR DESCRIPTION
Follow-up to #171, from verifying that change on dev. Reviewing a full AU Core run turned up a discrepancy between the two things that measure `TestRunner#run_test`: the `inferno.test` spans summed to 412.6s for the run, while the API's `duration_ms` summed to 226.0s over the same 498 tests.

The spans were right. `duration_ms` was read while building the arguments to `persist_result`, so the clock stopped before `Repositories::Results#create` ran.

## What that call costs

It writes a row per message and per request, and `Repositories::Requests#create` writes a row per HTTP header, one INSERT at a time. Over session `bcT7dNjmwrt` (498 tests, run duration 414.8s):

| | | |
|---|---|---|
| Executing tests | 226.0 s | 54% |
| Writing their results | 186.6 s | 45% |
| Everything else in the run | 2.2 s | 1% |

38,139 rows, 29,889 of them headers. It is not database latency: a round trip to Postgres from the worker measures 0.25 ms, against roughly 100 ms per persisted request.

The shortfall was not a uniform offset. It tracked request count at r = 0.906, so it understated exactly the request-heavy tests the column exists to surface. `au_core_v210_draft_encounter_read_test` recorded 1.07s against 3.31s actually elapsed.

## The fix

A row cannot carry the cost of writing itself, so this takes two writes: the INSERT keeps the execution time, then an UPDATE corrects it to the full elapsed time. One row by primary key per result, 533 for that run against the 38,139 INSERTs already being performed.

Taking the second reading inside `persist_result` rather than in `run_test` bounds it to the write itself and excludes the parent roll-up `run_group` performs afterwards.

## Second commit: keeping the split visible

Folding persistence into `duration_ms` makes the number honest but removes the only way to *see* the split, which was differencing the column against the span. So the second commit adds an `inferno.persist_result` child span over the write, carrying `inferno.messages_persisted` and `inferno.requests_persisted`.

Nothing else can see this cost. It is not an HTTP call, so no instrumentation covers it, and it sits inside `run_test`, so it is already inside the test span and the column without being separable in either.

## The alternative I did not take

`duration_ms` could instead have been defined as execution time excluding persistence, leaving it a single write and relabelling the docs and dashboard panels. I rejected it: the number is user-facing, and a typical test reporting a third of the time the user waited for it is not a definition worth documenting. Say the word if you would rather have the single write.

## Verified

- 51 examples, 0 failures. New coverage for the two-write behaviour, that a roll-up gets neither the insert value nor the corrective update, that the returned entity agrees with the row, and for the span's nesting and row counts.
- A spec now asserts `start`, `run_test` and `persist_result` stay public on `TestRunner`. A `private` placed above a wrapper in a prepended module makes the wrapped method private on the class too, which would break `Jobs::ExecuteTestRun` calling `start`, and only at runtime. I hit this while writing the change.

Not yet run end to end on dev, since that needs this merged and the image bumped. Once deployed, the check is that summed `duration_ms` and summed `inferno.test` span duration for a session agree within tracing overhead.

## Worth raising separately

Per-row persistence being 45% of a run is an inferno-core performance issue in its own right, independent of how it is measured. Batching the header and request inserts looks like the largest single lever on run time available anywhere in the stack, and it is upstream of anything this repository can fix.