### PR TITLE
fix: give the persistence span its own identity

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -58,12 +58,29 @@ per message, a row per request and a row per HTTP header, one INSERT at a time.
 
 | Attribute | Why |
 |---|---|
+| `inferno.test_session_id`, `inferno.test_run_id`, `inferno.suite_id` | same names as the test span, so the two filter and aggregate alike |
+| `inferno.test_id` *or* `inferno.group_id` | which runnable was written; neither on a suite roll-up |
 | `inferno.messages_persisted` | rows written for this result's messages |
 | `inferno.requests_persisted` | rows written for this result's requests; the count the cost tracks |
 
 It has a span because nothing else can see it. It is not an HTTP call, so no instrumentation
 covers it, and it sits inside `run_test`, so it is already counted in the test span and in
 `results.duration_ms` without being separable from test execution there.
+
+It repeats the parent's identity rather than relying on being a child of it. TraceQL `span.`
+filters match attributes on the span itself, so without those a session-scoped query written
+the way every other one is written returns nothing, and only a trace-level conjunction
+reaches it:
+
+```
+{ span.inferno.test_session_id = "<session>" } && { name = "inferno.persist_result" }
+```
+
+That form works for search and `select()`, but it returns the matched spans from **both**
+filters, so a table gets a spurious near-empty row per trace, and an aggregate grouped by a
+dimension only the test span carries splits in two. Measured on dev before the attributes
+were added, `sum_over_time(duration) by (span.inferno.suite_id)` over that conjunction
+returned two series, `au_core_v210_draft` and `nil`, with every persist span in `nil`.
 
 It is not a minor cost. On a 498-test AU Core run on dev (session `bcT7dNjmwrt`, 414.8 s):
 
@@ -79,8 +96,15 @@ round trip to Postgres from the worker measures 0.25 ms.
 
 ```
 { span.inferno.test_session_id = "<session>" && name = "inferno.persist_result" }
-  | select(span.inferno.requests_persisted)
+  | select(span.inferno.test_id, span.inferno.requests_persisted)
+
+{ span.inferno.test_session_id = "<session>" && name = "inferno.persist_result" }
+  | sum_over_time(duration) by (span.inferno.group_id)
 ```
+
+The second is a TraceQL metrics query, so it is limited to the last 20 minutes on this Tempo.
+See [Why the span name is a constant](#why-the-span-name-is-a-constant) for that limit and
+for why `quantile_over_time` is the wrong aggregate here.
 
 ## Why the span name is a constant
 
@@ -104,12 +128,25 @@ into table columns, and TraceQL metrics aggregate by them:
   | select(span.inferno.test_short_id, span.inferno.test_title, span.inferno.result)
 
 { span.inferno.test_run_id = "<uuid>" && name = "inferno.test" }
-  | quantile_over_time(duration, .95) by (span.inferno.group_id)
+  | max_over_time(duration) by (span.inferno.group_id)
 ```
 
-TraceQL metrics (the `| rate()` and `| quantile_over_time()` forms) are served from Tempo's
-live-store and only cover roughly the **last 20 minutes**; outside that window they error
-rather than return empty. Plain search covers full retention.
+TraceQL metrics (the `| rate()`, `| max_over_time()` and `| quantile_over_time()` forms) are
+served from Tempo's live-store and only cover roughly the **last 20 minutes**; outside that
+window they error rather than return empty. Plain search covers full retention.
+
+**Avoid `quantile_over_time` on these spans.** It is computed from exponentially spaced
+buckets and returns the bucket bound rather than an interpolated value, so it reads high and
+lands on powers of two. Measured against a run whose slowest test took 41.1 s, in a group
+totalling 44.5 s:
+
+| | |
+|---|---|
+| `quantile_over_time(duration, .95)` | 68.7195 s (2^36 ns, 57% high) |
+| `max_over_time(duration)` | 43.6398 s |
+
+One span per test per run means a quantile has almost nothing to smooth anyway. Use
+`max_over_time` for "what was slowest" and `sum_over_time` for totals.
 
 ## Dashboards
 

--- a/lib/inferno_platform_template/test_tracing.rb
+++ b/lib/inferno_platform_template/test_tracing.rb
@@ -61,7 +61,20 @@ if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
     # It is worth its own span because nothing else can see it. It is not an HTTP call, so
     # no instrumentation covers it, and it is inside `run_test`, so it is already counted
     # in the test span and in `results.duration_ms` without being distinguishable there.
-    # As a child of the test span it also inherits that test's identity for free.
+    #
+    # It carries its own identity rather than relying on the parent test span for it.
+    # Being a child is not enough: TraceQL's `span.` filters match attributes on the span
+    # itself, so a session-scoped panel written the way every other one is written returns
+    # nothing, and only a trace-level conjunction reaches it:
+    #
+    #   { span.inferno.test_session_id = "..." } && { name = "inferno.persist_result" }
+    #
+    # That form works for search and select(), but it returns the matched spans from both
+    # filters, so a table gets a spurious near-empty row per trace, and an aggregate
+    # grouped by a dimension only the test span carries splits in two. Measured on dev
+    # before this change, `sum_over_time(duration) by (span.inferno.suite_id)` over that
+    # conjunction returned two series, `au_core_v210_draft` and `nil`, with every one of
+    # the persist spans in `nil`.
     def persist_result(params)
       tracer.in_span(PERSIST_SPAN_NAME, attributes: persist_span_attributes(params)) { super }
     end
@@ -84,11 +97,22 @@ if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
 
     # The row counts are what make a slow write explicable rather than merely visible: the
     # cost tracks the number of requests being written almost exactly.
+    #
+    # The runnable id comes from the params, because `persist_result` receives the
+    # runnable's `reference_hash` merged in and is called for groups and suite roll-ups as
+    # well as tests. Exactly one of `test_id` / `test_group_id` is present on any given
+    # write, neither on a suite, and `compact` drops the absent ones rather than exporting
+    # nils. Attribute names match the test span's, so the two aggregate together.
     def persist_span_attributes(params)
       {
+        'inferno.test_session_id' => test_session.id,
+        'inferno.test_run_id' => test_run.id,
+        'inferno.suite_id' => test_session.test_suite_id,
+        'inferno.test_id' => params[:test_id],
+        'inferno.group_id' => params[:test_group_id],
         'inferno.messages_persisted' => (params[:messages] || []).size,
         'inferno.requests_persisted' => (params[:requests] || []).size
-      }
+      }.compact
     end
 
     def run_span_attributes

--- a/spec/inferno_deployment/per_test_trace_root_spec.rb
+++ b/spec/inferno_deployment/per_test_trace_root_spec.rb
@@ -155,7 +155,10 @@ RSpec.describe PerTestTraceRoot do
 
   describe 'the result-persistence span' do
     # Two messages and three requests, which is all the patch reads from the params.
-    let(:params) { { messages: [{}, {}], requests: [{}, {}, {}] } }
+    let(:params) do
+      { messages: [{}, {}], requests: [{}, {}, {}],
+        test_id: 'au_core_v210_draft-patient_group-patient_read_test' }
+    end
 
     before { runner.persist_params = params }
 
@@ -186,6 +189,36 @@ RSpec.describe PerTestTraceRoot do
 
       expect(persist_span.attributes['inferno.messages_persisted']).to eq(0)
       expect(persist_span.attributes['inferno.requests_persisted']).to eq(0)
+    end
+
+    # Being a child of the test span is not enough. TraceQL `span.` filters match
+    # attributes on the span itself, so without these a session-scoped panel written the
+    # usual way returns nothing and only a trace-level conjunction finds the span.
+    it 'carries the session and run, so it can be filtered like every other span' do
+      expect(persist_span.attributes['inferno.test_session_id']).to eq('session-uuid')
+      expect(persist_span.attributes['inferno.test_run_id']).to eq('run-uuid')
+      expect(persist_span.attributes['inferno.suite_id']).to eq('au_core_v210_draft')
+    end
+
+    it 'names the runnable it wrote, so the cost can be grouped by test' do
+      expect(persist_span.attributes['inferno.test_id'])
+        .to eq('au_core_v210_draft-patient_group-patient_read_test')
+      expect(persist_span.attributes).to_not have_key('inferno.group_id')
+    end
+
+    it 'names a group write by its group id instead' do
+      runner.persist_params = { test_group_id: 'au_core_v210_draft-patient_group' }
+
+      expect(persist_span.attributes['inferno.group_id']).to eq('au_core_v210_draft-patient_group')
+      expect(persist_span.attributes).to_not have_key('inferno.test_id')
+    end
+
+    it 'omits both on a suite roll-up rather than exporting nils' do
+      runner.persist_params = { test_suite_id: 'au_core_v210_draft' }
+
+      expect(persist_span.attributes).to_not have_key('inferno.test_id')
+      expect(persist_span.attributes).to_not have_key('inferno.group_id')
+      expect(persist_span.attributes['inferno.test_session_id']).to eq('session-uuid')
     end
 
     it 'passes the persisted result through unchanged' do


### PR DESCRIPTION
Found while running #173 end to end on dev. The verification itself passed cleanly (numbers below); this is the one gap it exposed.

## The gap

`inferno.persist_result` carried only its two row counts, relying on being a child of the test span for the rest. TraceQL `span.` filters match attributes on the span itself, so the span was invisible to a query written the way every panel on the Run Timing dashboard is written:

| Query | Hits |
|---|---|
| `{ name = "inferno.persist_result" }` | 50 |
| `{ span.inferno.test_session_id = "…" && name = "inferno.persist_result" }` | **0** |
| `{ span.inferno.test_session_id = "…" } && { name = "inferno.persist_result" }` | 50 |

Only the trace-level conjunction reached it. That form works for search and `select()`, but it returns the matched spans from *both* filters, so a table gets a spurious near-empty row per trace, and an aggregate grouped by a dimension only the test span carries splits in two. On dev, `sum_over_time(duration) by (span.inferno.suite_id)` over the conjunction returned two series, `au_core_v210_draft` and `nil`, with every persist span in `nil`.

The span now carries `test_session_id`, `test_run_id` and `suite_id`, plus `test_id` or `group_id` for the runnable written, from the `reference_hash` `TestRunner` merges into the params. Names match the test span's, so the two aggregate together.

Also corrects the tracing doc, which recommended `quantile_over_time` in its worked example. #220 established that reads the exponential bucket bound: 68.72 s against a real 43.64 s.

## The #173 verification that found it

Full AU Core run on dev, session `4BsIECmriCF`, 498 tests, run duration 383.2 s.

| | Before #173 | After #173 |
|---|---|---|
| Sum `duration_ms` | 226.0 s | **378.4 s** |
| Sum `inferno.test` span duration | 412.6 s | 381.2 s |
| Gap | 45% | **0.7%** |

Median per-test gap is now 5 ms, which is the tracing overhead itself, and no span is shorter than its column. The two independent measurements of `run_test` agree.

The 500 persist spans account for 159.5 s, 42% of the run, over 1,705 requests and 4,310 messages, at 94 ms per persisted request. That matches the 100 ms/request derived by differencing on the previous run, now measured directly rather than inferred.

## Verified

55 examples, 0 failures. New coverage for the session/run/suite attributes, for a group write being labelled `group_id` instead of `test_id`, and for a suite roll-up omitting both rather than exporting nils.