### PR TITLE
Promote prod -> v1.1.0

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d
   usesWrapper: true
   # HELD AT 1.0.78. Prod stays pinned (never :latest) so promotions are explicit, but
   # this pin is now a deliberate hold rather than a lag: do not advance it without
@@ -39,7 +39,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:0d05749081407f8ac8f9bb730b99e83a40161e49-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `0d05749` → `67a5664` — staging already runs this exact artifact.

## Release version
Proposed: **v1.1.0** (minor bump of `v1.0.2`).

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`0d05749`)
**- AU PS R1 1.0.0 release https://github.com/hl7au/au-ps-inferno/releases/tag/v1.0.0**  (#177)
- Update AU Core test kit to version 1.4.4 and adjust related documentation (#165)
- perf(validator): right-size JVM heap from live-heap telemetry, pin reload guard (#156)
- Security and performance fix 504s on concurrent test-session creation (#159)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/0d05749081407f8ac8f9bb730b99e83a40161e49...67a5664c3d8aa959e90e218a4556b92f2678c41d

- app:   `ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d-nginx`
