### PR TITLE
Add a scheduled refresh of the validator terminology cache

### DIFF
--- a/infra/helm/inferno/templates/jobs/tx-cache-refresh.cronjob.yaml
+++ b/infra/helm/inferno/templates/jobs/tx-cache-refresh.cronjob.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.txCacheRefresh.enabled }}
+# Scheduled refresh of the validator's terminology cache.
+#
+# WHY THIS EXISTS. The validator writes $validate-code responses to the shared on-disk
+# cache at /tmp/default-tx-cache (the validator-terminology-cache PVC) and those entries
+# have NO TTL. Failures are cached verbatim alongside successes, so a single bad answer is
+# replayed for the life of the volume. Only the TerminologyCapabilities snapshot
+# self-expires (CAPABILITY_CACHE_EXPIRATION_HOURS = 24 in org.hl7.fhir.core); nothing
+# expires the validate-code entries.
+#
+# The cache key embeds the expansion Parameters, including
+# "system-version=http://snomed.info/sct|http://snomed.info/sct/<edition>". Because the
+# test kits select an EDITION rather than a dated version, that key is stable across
+# monthly SNOMED AU releases, so cached answers never roll over on their own. Hence a
+# schedule.
+#
+# HOW IT WORKS. Two steps, both required:
+#
+#   1. POST a throwaway validation with cliContext.clearTxCache=true. This wipes the whole
+#      cache DIRECTORY (verified: an unrelated marker file placed in the folder is gone
+#      afterwards), which no pod restart would do on its own since the PVC survives
+#      restarts.
+#   2. Restart the validator Deployment. Step 1 only clears the engine that served it;
+#      other live engines keep their in-memory copies, and prod pins
+#      SESSION_CACHE_DURATION=-1 so those engines never expire on their own.
+#
+# The warmer sidecar re-warms on start (see configs/validator-warmer-configmap.yaml), so
+# the cache repopulates with fresh answers without further help.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tx-cache-refresh
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tx-cache-refresh
+  namespace: {{ .Release.Namespace }}
+rules:
+  # get/list/watch back `kubectl rollout status`; patch is what `rollout restart` issues.
+  # Scoped to this namespace, and to Deployments only.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tx-cache-refresh
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tx-cache-refresh
+subjects:
+  - kind: ServiceAccount
+    name: tx-cache-refresh
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tx-cache-refresh
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: {{ .Values.txCacheRefresh.schedule | quote }}
+  timeZone: {{ .Values.txCacheRefresh.timeZone | quote }}
+  # A wipe plus a validator restart must never overlap another one, and a missed run is
+  # not worth catching up on: the next month's run subsumes it.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: tx-cache-refresh
+          restartPolicy: Never
+          # Step 1. Wipe the shared on-disk cache. The engine this builds is thrown away
+          # by the restart in step 2, so it deliberately loads no IGs.
+          initContainers:
+            - name: clear-tx-cache
+              image: {{ .Values.txCacheRefresh.curlImage | quote }}
+              command: ["sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  cat >/tmp/payload.json <<'PAYLOAD'
+                  {
+                    "cliContext": {
+                      "clearTxCache": true,
+                      "txServer": "{{ .Values.inferno.terminologyServer }}",
+                      "noEcosystem": true,
+                      "profiles": ["http://hl7.org/fhir/StructureDefinition/Patient"]
+                    },
+                    "filesToValidate": [
+                      {
+                        "fileName": "Patient/tx-cache-refresh.json",
+                        "fileContent": "{\"resourceType\":\"Patient\"}",
+                        "fileType": "json"
+                      }
+                    ],
+                    "sessionId": null
+                  }
+                  PAYLOAD
+                  echo "Clearing terminology cache via validator-api..."
+                  curl --fail --silent --show-error --max-time 900 \
+                    -X POST http://validator-api:3500/validate \
+                    -H 'Content-Type: application/json' \
+                    --data-binary @/tmp/payload.json \
+                    -o /dev/null
+                  echo "Terminology cache cleared."
+          # Step 2. Drop every in-memory engine cache. Recreate strategy means the old pod
+          # releases the RWO PVCs before the new one mounts them.
+          containers:
+            - name: restart-validator
+              image: {{ .Values.txCacheRefresh.kubectlImage | quote }}
+              command: ["sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  kubectl rollout restart deployment/validator-api
+                  kubectl rollout status deployment/validator-api --timeout=15m
+{{- end }}

--- a/infra/helm/inferno/values.schema.json
+++ b/infra/helm/inferno/values.schema.json
@@ -146,6 +146,18 @@
         "recheckInterval": { "type": "integer", "minimum": 1 }
       }
     },
+    "txCacheRefresh": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "timeZone": { "type": "string" },
+        "curlImage": { "type": "string" },
+        "kubectlImage": { "type": "string" }
+      }
+    },
     "autoscaling": {
       "type": "object",
       "additionalProperties": false,

--- a/infra/helm/inferno/values.yaml
+++ b/infra/helm/inferno/values.yaml
@@ -305,6 +305,26 @@ warmer:
   pollTimeout: 300      # max seconds to wait for a warm run to finish
   recheckInterval: 30   # seconds between (cheap, local) validator-restart checks
 
+# Scheduled wipe of the validator's terminology cache
+# (templates/jobs/tx-cache-refresh.cronjob.yaml). The validator caches $validate-code
+# responses on the terminology PVC with NO TTL, failures included, so without this a bad
+# or superseded answer is replayed for the life of the volume. Only the
+# TerminologyCapabilities snapshot self-expires, after 24h.
+txCacheRefresh:
+  enabled: true
+  # SNOMED CT AU releases on the last day of each month. This runs on the 3rd, a couple of
+  # days later, at a quiet local hour. The cost of a run is one validator restart plus the
+  # warmer's re-warm, so monthly is the right granularity: matching the release cadence
+  # bounds staleness at ~1 release without paying a cold rebuild any more often.
+  #
+  # Because the test kits select a SNOMED EDITION rather than a dated version, the cache
+  # key is identical across releases and nothing rotates on its own. If that ever changes
+  # to a pinned dated version, keys rotate naturally and this can be relaxed.
+  schedule: "0 2 3 * *"
+  timeZone: "Australia/Sydney"
+  curlImage: "curlimages/curl:8.11.1"
+  kubectlImage: "bitnami/kubectl:1.31.4"
+
 postgresql:
   enabled: false # enable if not using rds from aws-impl
   externaldbhost: null # This can be overridden during chart deployment


### PR DESCRIPTION
## Problem

The validator writes `$validate-code` responses to the shared on-disk cache at `/tmp/default-tx-cache` (the `validator-terminology-cache` PVC) with **no TTL**, and caches failures verbatim alongside successes. A single bad or superseded answer is replayed for the life of the volume. Only the `TerminologyCapabilities` snapshot self-expires, after 24h (`CAPABILITY_CACHE_EXPIRATION_HOURS` in `org.hl7.fhir.core`).

This was directly observable on dev. Its validator reported seven valid SNOMED CT AU versions ending at `20260531`; a clean validator against the same terminology server reported nine, ending at `20260731`. Two releases of drift, served from the PVC.

Nothing rotates the entries. Inspecting a live cache file confirms the key embeds the expansion Parameters:

```
"system-version": "http://snomed.info/sct|http://snomed.info/sct/900000000000207008"
```

Because the test kits select an *edition* rather than a dated version, that key is identical across monthly releases, so cached answers never roll over on their own.

## Change

A monthly CronJob on the 3rd, a couple of days after the SNOMED CT AU release on the last day of each month. Two steps, both required:

1. **Wipe the disk cache.** A throwaway validation with `cliContext.clearTxCache=true`. Verified against `validator-wrapper:1.0.81` that this clears the whole directory: a marker file placed in the folder beforehand is gone afterwards. No pod restart does this, because the PVC survives restarts.
2. **Restart the validator.** Step 1 only clears the engine that served it. Other live engines keep their in-memory copies, and prod pins `SESSION_CACHE_DURATION=-1` so they never expire on their own. Conversely a restart alone is not enough either, since the new pod reloads the stale entries from the PVC.

The warmer sidecar re-warms on start, so the cache repopulates with fresh answers unaided.

## RBAC

A namespace-scoped `Role` limited to `apps/deployments` with `get`, `list`, `watch`, `patch`. `patch` is what `rollout restart` issues; the rest back `rollout status`. First RBAC in this chart, gated behind `txCacheRefresh.enabled` with the CronJob.

## Notes

Fixing the SNOMED edition selection in the test kits (hl7au/au-ps-inferno#108, hl7au/au-fhir-core-inferno#299) removes the *source* of the cached failures, but is orthogonal to this: positive answers go stale too, just less visibly.

Renders clean against both dev and prod values, including the strict `values.schema.json`.