### PR TITLE
[DO NOT MERGE] Preview: AU PS SNOMED CT edition fix

### DIFF
--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -17,4 +17,10 @@ gem 'au_core_test_kit', '>= 1.4.4'
 
 
 # Bleeding-edge AU PS test kit — unreleased commit ahead of the RubyGems release.
-gem 'au_ps_inferno', '>= 1.0.0'
+#
+# Pinned to the SNOMED CT edition fix (hl7au/au-ps-inferno#108) so dev and previews can
+# exercise it before it reaches RubyGems. The suite left cliContext.snomedCT at the
+# validator's International default, which the AU terminology server does not carry.
+# Move back to a version constraint once that lands in an au_ps_inferno release.
+gem 'au_ps_inferno', git: 'https://github.com/hl7au/au-ps-inferno',
+                     ref: '531aefd5485e3977c506d953ee0652c67ee22d74'

--- a/Gemfile.dev.lock
+++ b/Gemfile.dev.lock
@@ -7,6 +7,14 @@ GIT
       inferno_core (>= 0.4.2)
 
 GIT
+  remote: https://github.com/hl7au/au-ps-inferno
+  revision: 531aefd5485e3977c506d953ee0652c67ee22d74
+  ref: 531aefd5485e3977c506d953ee0652c67ee22d74
+  specs:
+    au_ps_inferno (1.0.0)
+      inferno_core (~> 1.0.6)
+
+GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
   revision: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
   ref: 9b0d17ef2ade2027cce33cca5539f84ab5bf5f85
@@ -34,8 +42,6 @@ GEM
       inferno_core (>= 1.0.6)
       smart_app_launch_test_kit (>= 0.4.0)
       tls_test_kit (~> 0.2.0)
-    au_ps_inferno (1.0.0)
-      inferno_core (~> 1.0.6)
     auth-sanitizer (0.2.2)
       version_gem (~> 1.1, >= 1.1.10)
     base62-rb (0.3.1)
@@ -525,7 +531,7 @@ PLATFORMS
 
 DEPENDENCIES
   au_core_test_kit (>= 1.4.4)
-  au_ps_inferno (>= 1.0.0)
+  au_ps_inferno!
   connection_pool (~> 2.5)
   database_cleaner-sequel (~> 1.8)
   factory_bot (~> 6.1)


### PR DESCRIPTION
**Throwaway PR to stand up a preview environment. Do not merge; close it when the preview has served its purpose.**

Pins `au_ps_inferno` in `Gemfile.dev` to [hl7au/au-ps-inferno@531aefd](https://github.com/hl7au/au-ps-inferno/commit/531aefd5485e3977c506d953ee0652c67ee22d74), the head of hl7au/au-ps-inferno#108, so the SNOMED CT edition fix can be exercised end-to-end before it reaches RubyGems.

## What to check once the preview is live

Run **AU PS 1.0.0 → AU PS Bundle Instance**, paste the `aups-basicsummary` example, and look at **1.2.01 Bundle is valid against AU PS Bundle**.

| | before | expected after |
|---|---|---|
| errors | 1 | **0** |
| warnings | 28 | **8** |
| info | 19 | **9** |

Specifically, these should all be gone:

- `error` — `Bundle.entry[8].resource.medication.ofType(Reference): Unable to find a profile match for #bisoprolol`
- every `A definition for CodeSystem 'http://snomed.info/sct' version 'null' could not be found`
- every `None of the codings provided are in the value set` naming an AU/NCTS value set
- `Constraint failed: inv-pat-1`
- `section[2].entry[0]: This element does not match any known slice`

The 8 that remain are genuine and unrelated to this change: four `Found multiple matching profiles` (AU Base lists base `Identifier`/`Address` alongside the specialised profiles) and three duplicate reports that `v2-0203#EI` is absent from the R4 `identifier-type` value set, plus the PractitionerRole identifier slice info.

## Why a preview rather than dev

A preview gets a fresh namespace: new Postgres, so no stale `validator_sessions` rows, and new PVCs, so no stale terminology cache. Both of those would otherwise mask the change on an existing environment. It is the only environment where this can be observed cleanly without manual intervention.

## Scope

AU Core is deliberately left on its current pin so this preview isolates one variable. hl7au/au-fhir-core-inferno#299 carries the equivalent fix and can be added here if you want both exercised together.