### PR TITLE
Promote prod -> v1.1.1

### DIFF
--- a/infra/helm/inferno/values-prod.yaml
+++ b/infra/helm/inferno/values-prod.yaml
@@ -11,7 +11,7 @@ redirectIngress:
   targetUrl: "https://inferno.hl7.org.au"
 
 inferno:
-  imageUrl: ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d
+  imageUrl: ghcr.io/hl7au/au-fhir-inferno:c4d9207ca10e1b1660fc28e72476cf5ff6968b2d
   usesWrapper: true
   # HELD AT 1.0.78. Prod stays pinned (never :latest) so promotions are explicit, but
   # this pin is now a deliberate hold rather than a lag: do not advance it without
@@ -39,7 +39,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 
 nginx:
-  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:67a5664c3d8aa959e90e218a4556b92f2678c41d-nginx
+  platformImageUri: ghcr.io/hl7au/au-fhir-inferno:c4d9207ca10e1b1660fc28e72476cf5ff6968b2d-nginx
 
 
 externalSecrets:


### PR DESCRIPTION
Promote prod `67a5664` → `c4d9207` — staging already runs this exact artifact.

## Release version
Proposed: **v1.1.1** (patch bump of `v1.1.0`).
To choose a different version, edit this PR's **title** to end with `-> vX.Y.Z`,
or apply a `release:major` / `release:minor` / `release:patch` label before merging.

## Risk flags
- Dependencies / test kits (`Gemfile.lock`): **⚠️ CHANGED**
- App code / static site (`web/`, `lib/`): **⚠️ CHANGED**
- Helm chart (`infra/**`): **⚠️ CHANGED** — already synced to prod via ArgoCD (informational)

## Changelog since current prod (`67a5664`)
- Use latest au core inferno gem to provide v300-ballot1 version (#186)

Full code diff: https://github.com/hl7au/au-fhir-inferno/compare/67a5664c3d8aa959e90e218a4556b92f2678c41d...c4d9207ca10e1b1660fc28e72476cf5ff6968b2d

- app:   `ghcr.io/hl7au/au-fhir-inferno:c4d9207ca10e1b1660fc28e72476cf5ff6968b2d`
- nginx: `ghcr.io/hl7au/au-fhir-inferno:c4d9207ca10e1b1660fc28e72476cf5ff6968b2d-nginx`
