### PR TITLE
fix: stop intermittent 503 UC responses on the inferno route

### DIFF
--- a/infra/helm/inferno/templates/configs/inferno-backendtrafficpolicy.yaml
+++ b/infra/helm/inferno/templates/configs/inferno-backendtrafficpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: inferno-route-resilience
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: inferno-route
+  timeout:
+    http:
+      # Must stay below the nginx keepalive_timeout (600s) so Envoy closes
+      # idle upstream connections before nginx does. Otherwise nginx can
+      # close a pooled connection just as Envoy reuses it, which surfaces
+      # as a 503 UC (upstream_reset_before_response_started).
+      connectionIdleTimeout: 300s
+  retry:
+    numRetries: 2
+    retryOn:
+      triggers:
+        # reset-before-request only retries when the connection died before
+        # the request was written, so it is safe for non-idempotent requests.
+        - reset-before-request
+        - connect-failure


### PR DESCRIPTION
## Problem

The gateway returns 25 to 30 intermittent 503s per day on inferno.hl7.org.au. Envoy access logs show `response_flags: UC`, `upstream_reset_before_response_started{connection_termination}`, all on requests to the nginx backend (rule/1 of inferno-route). Over the last two days every occurrence was an Uptime-Kuma `GET /` health probe, so the external monitor sees the site flap. One of these also showed up in the 12:12 AEST gateway 5xx alert today (2026-08-11).

## Root cause

nginx closes idle keepalive connections after 600s (`keepalive_timeout`), while Envoy pools upstream connections for up to its 1 hour default idle timeout. When a request reuses a pooled connection at the moment nginx closes it, the request is reset before a response starts and the client gets a 503.

## Fix

A `BackendTrafficPolicy` targeting `inferno-route`:

- `connectionIdleTimeout: 300s` keeps Envoy's upstream idle timeout below nginx's 600s, so Envoy always closes idle connections first and never reuses one nginx has torn down.
- Retry on `reset-before-request` and `connect-failure` (2 retries) covers residual resets from pod rollouts and node churn. `reset-before-request` only fires when the request was never written to the connection, so it cannot double-execute a POST (unlike the bare `reset` trigger).

## Validation

- `helm template` renders cleanly with values.yaml + values-prod.yaml.
- Server-side dry-run apply against the sparkey cluster (Envoy Gateway v1.8.2) accepts the resource, including the `reset-before-request` trigger enum.
- Follows the existing precedent of `BackendTrafficPolicy` use on this gateway (`smilecdr-request-buffer` in the smile namespace).